### PR TITLE
[Refactor] 회원가입 서비스 리팩토링 및 부가 어노테이션 추가

### DIFF
--- a/src/main/java/com/clover/bookflow/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/clover/bookflow/domain/user/repository/UserRepository.java
@@ -7,4 +7,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
   boolean existsByEmail(String email);
 
+  boolean existsByNickname(String nickname);
+
 }

--- a/src/main/java/com/clover/bookflow/domain/user/service/UserService.java
+++ b/src/main/java/com/clover/bookflow/domain/user/service/UserService.java
@@ -4,24 +4,27 @@ import com.clover.bookflow.domain.user.dto.request.UserSignupRequest;
 import com.clover.bookflow.domain.user.dto.response.UserSignupResponse;
 import com.clover.bookflow.domain.user.entity.User;
 import com.clover.bookflow.domain.user.repository.UserRepository;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
+@RequiredArgsConstructor // 생성자 주입이 더 안전, 깔끔
 public class UserService {
 
-  @Autowired
-  private UserRepository userRepository;
+  private final UserRepository userRepository;
 
-  @Autowired
-  private PasswordEncoder passwordEncoder;
+  private final PasswordEncoder passwordEncoder;
 
+  @Transactional
   public UserSignupResponse signup(UserSignupRequest request) {
+    log.info("회원가입 시도: {}", request);
+
     // 이메일 중복 체크 (비즈니스 유효성 검증)
-    if (userRepository.existsByEmail(request.email())) {
-      throw new IllegalArgumentException("이미 가입된 이메일입니다.");
-    }
+    validateEmail(request.email());
 
     String encodedPassword = passwordEncoder.encode(request.password());
 
@@ -30,6 +33,12 @@ public class UserService {
     userRepository.save(user);
 
     return UserSignupResponse.from(user);
+  }
+
+  private void validateEmail(String email) {
+    if (userRepository.existsByEmail(email)) {
+      throw new IllegalArgumentException("이미 가입된 이메일입니다.");
+    }
   }
 
 

--- a/src/main/java/com/clover/bookflow/domain/user/service/UserService.java
+++ b/src/main/java/com/clover/bookflow/domain/user/service/UserService.java
@@ -23,8 +23,12 @@ public class UserService {
   public UserSignupResponse signup(UserSignupRequest request) {
     log.info("회원가입 시도: {}", request);
 
-    // 이메일 중복 체크 (비즈니스 유효성 검증)
-    validateEmail(request.email());
+    // 입력값 자체 검사는 커스텀 어노테이션
+    // db 조회 필요한 검사는 서비스에서 처리
+
+    // 이메일, 닉네임 중복 체크 (비즈니스 유효성 검증)
+    validateDuplicateEmail(request.email());
+    validateDuplicateNickname(request.nickname());
 
     String encodedPassword = passwordEncoder.encode(request.password());
 
@@ -35,9 +39,15 @@ public class UserService {
     return UserSignupResponse.from(user);
   }
 
-  private void validateEmail(String email) {
+  private void validateDuplicateEmail(String email) {
     if (userRepository.existsByEmail(email)) {
       throw new IllegalArgumentException("이미 가입된 이메일입니다.");
+    }
+  }
+
+  private void validateDuplicateNickname(String nickname) {
+    if (userRepository.existsByNickname(nickname)) {
+      throw new IllegalArgumentException("이미 존재하는 닉네임입니다.");
     }
   }
 

--- a/src/test/java/com/clover/bookflow/domain/user/integration/UserIntegrationTest.java
+++ b/src/test/java/com/clover/bookflow/domain/user/integration/UserIntegrationTest.java
@@ -2,6 +2,8 @@ package com.clover.bookflow.domain.user.integration;
 
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.clover.bookflow.config.AbstractIntegrationTest;
 import com.clover.bookflow.domain.user.dto.request.UserSignupRequest;
@@ -26,10 +28,13 @@ public class UserIntegrationTest extends AbstractIntegrationTest {
   void signup_success() throws Exception {
     UserSignupRequest request = new UserSignupRequest("hkd111@example.com", "password123", "길똥이");
     mockMvc.perform(post("/users/signup")
-        .contentType(MediaType.APPLICATION_JSON)
-        .content(new ObjectMapper().writeValueAsString(request))
-        .with(csrf())
-    );
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(new ObjectMapper().writeValueAsString(request))
+            .with(csrf())
+        )
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.email").value("hkd111@example.com"))
+        .andExpect(jsonPath("$.nickname").value("길똥이"));
   }
 
 

--- a/src/test/java/com/clover/bookflow/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/clover/bookflow/domain/user/service/UserServiceTest.java
@@ -10,12 +10,12 @@ import com.clover.bookflow.domain.user.dto.request.UserSignupRequest;
 import com.clover.bookflow.domain.user.dto.response.UserSignupResponse;
 import com.clover.bookflow.domain.user.entity.User;
 import com.clover.bookflow.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -29,8 +29,13 @@ public class UserServiceTest {
   @Mock
   private PasswordEncoder passwordEncoder;
 
-  @InjectMocks
   private UserService userService;
+
+  // 필드 주입에서 생성자 주입으로 변경으로 인한 수정
+  @BeforeEach
+  void setUp() {
+    userService = new UserService(userRepository, passwordEncoder);
+  }
 
   @Nested
   @DisplayName("회원 가입")

--- a/src/test/java/com/clover/bookflow/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/clover/bookflow/domain/user/service/UserServiceTest.java
@@ -41,8 +41,8 @@ public class UserServiceTest {
   @DisplayName("회원 가입")
   class signup {
 
-    @Test
     @DisplayName("회원 가입 성공 테스트")
+    @Test
     void signup_success() {
       // given
       UserSignupRequest request = new UserSignupRequest("hkd111@example.com",
@@ -76,8 +76,8 @@ public class UserServiceTest {
     }
 
     // 이메일 중복시 회원 가입 실패
-    @Test
     @DisplayName("이미 가입된 이메일로 회원 가입하면 예외가 발생한다.")
+    @Test
     void should_ThrowException_When_EmailAlreadyExists() {
       // given
       UserSignupRequest userSignupRequest = new UserSignupRequest("hkd111@example.com",
@@ -90,6 +90,23 @@ public class UserServiceTest {
 
       // then
       assertThat(e.getMessage()).isEqualTo("이미 가입된 이메일입니다.");
+    }
+
+    // 닉네임 중복 시 회원 가입 실패
+    @DisplayName("이미 존재하는 닉네임으로 회원 가입 시 예외가 발생한다.")
+    @Test
+    void should_ThrowException_When_NicknameAlreadyExists() {
+      // given
+      UserSignupRequest userSignupRequest = new UserSignupRequest("hkd111@example.com",
+          "password123", "길똥이");
+      given(userRepository.existsByNickname("길똥이")).willReturn(true);
+
+      // when
+      IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+          () -> userService.signup(userSignupRequest));
+
+      // then
+      assertThat(e.getMessage()).isEqualTo("이미 존재하는 닉네임입니다.");
     }
   }
 


### PR DESCRIPTION
# [#7] 회원가입 서비스 리팩토링 및 부가 어노테이션 추가

---

## 📌 개요
- 회원가입 서비스 로직 리팩토링

---

## ✨ 주요 변경 사항
- **UserService**: 회원가입 서비스 로직 리팩토링
  - 이메일 중복 검사 메서드 분리
  - 의존성 주입 방식 변경
  - 로그 어노테이션 적용
  - 트랜잭션 처리 추가 
- 닉네임 중복 검사 기능 추가
- 회원가입 서비스 단위 테스트 코드 수정
- 통합 테스트 수정
  - 회원 가입 응답 JSON 에서 email, nickname 필드에 대한 검증 추가

---

## ✅ 테스트
- [x] `UserServiceTest`

---

## 🎯 향후 작업 예정
- 회원가입 커스텀 유효성 검증 추가 및 실패 테스트 작성
- 로그인 기능 구현

---

## 🔗 관련 이슈
Closes #7