### PR TITLE
[Feature] 회원가입 컨트롤러 실패 테스트 작성 및 문서화

### DIFF
--- a/src/main/java/com/clover/bookflow/domain/user/dto/request/UserSignupRequest.java
+++ b/src/main/java/com/clover/bookflow/domain/user/dto/request/UserSignupRequest.java
@@ -7,16 +7,16 @@ import jakarta.validation.constraints.Size;
 // 단순 데이터 전달 용도의 DTO 이므로 record 사용 (불변성 보장)
 public record UserSignupRequest(
     // 입력값 검증은 Bean Validation (@Valid)를 사용하며, Controller 진입 직전에 처리
-    @NotBlank(message = "이메일은 필수입니다.")
-    @Email(message = "이메일 형식이 아닙니다.")
+    @NotBlank(message = "Email must not be blank")
+    @Email(message = "Invalid email format")
     String email,
 
-    @NotBlank(message = "비밀번호는 필수입니다.")
-    @Size(min = 8, message = "비밀번호는 8자 이상이어야 합니다.")
+    @NotBlank(message = "Password must not be blank")
+    @Size(min = 8, max = 20, message = "Password must be between 8 and 20 characters")
     String password,
 
-    @NotBlank(message = "닉네임은 필수입니다.")
-    @Size(min = 2, max = 20, message = "닉네임은 2자 이상 20자 이하여야 합니다.")
+    @NotBlank(message = "Nickname must not be blank")
+    @Size(min = 2, max = 20, message = "Nickname must be between 2 and 20 characters")
     String nickname
 ) {
 

--- a/src/main/java/com/clover/bookflow/global/security/SecurityConfig.java
+++ b/src/main/java/com/clover/bookflow/global/security/SecurityConfig.java
@@ -22,6 +22,7 @@ public class SecurityConfig {
     http
         .csrf(csrf -> csrf.disable())
         .authorizeHttpRequests(auth -> auth
+            .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/docs/**").permitAll()
             .requestMatchers("/users/signup").permitAll()
             .anyRequest().authenticated()
         )

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,6 +1,6 @@
 spring:
   config:
-    import: optional:file:.env[.properties]
+    import: optional:file:.env.dev[.properties]
 
   datasource:
     url: ${DB_URL}

--- a/src/test/java/com/clover/bookflow/common/ApiDocs.java
+++ b/src/test/java/com/clover/bookflow/common/ApiDocs.java
@@ -1,0 +1,34 @@
+package com.clover.bookflow.common;
+
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+
+import java.util.Arrays;
+import java.util.stream.Stream;
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.restdocs.payload.JsonFieldType;
+
+public class ApiDocs {
+
+  public static final FieldDescriptor[] COMMON_FIELDS = {
+      fieldWithPath("success").description("요청 성공 여부"),
+      fieldWithPath("code").description("응답 코드"),
+      fieldWithPath("message").description("응답 메시지"),
+      fieldWithPath("data").description("응답 데이터 (null일 수 있음 / 빈 배열일 수 있음)")
+          .type(JsonFieldType.OBJECT).optional(),
+      fieldWithPath("errors").description("입력 오류 상세 정보 배열 (빈 배열일 수 있음)")
+  };
+
+  public static final FieldDescriptor[] ERROR_DETAIL_FIELDS = {
+      fieldWithPath("errors[].field").description("오류 발생 필드"),
+      fieldWithPath("errors[].message").description("오류 메시지")
+  };
+
+  public static FieldDescriptor[] combineFields(FieldDescriptor[] base,
+      FieldDescriptor... additional) {
+    return Stream.concat(
+        Arrays.stream(base),
+        Arrays.stream(additional)
+    ).toArray(FieldDescriptor[]::new);
+  }
+
+}

--- a/src/test/java/com/clover/bookflow/common/TestHelper.java
+++ b/src/test/java/com/clover/bookflow/common/TestHelper.java
@@ -1,0 +1,53 @@
+package com.clover.bookflow.common;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+public class TestHelper {
+
+  private final MockMvc mockMvc;
+  private final ObjectMapper objectMapper;
+
+  public TestHelper(MockMvc mockMvc, ObjectMapper objectMapper) {
+    this.mockMvc = mockMvc;
+    this.objectMapper = objectMapper;
+  }
+
+  // post 요청
+  public ResultActions postRequest(String url, Object request) throws Exception {
+    return performRequest(post(url), request);
+  }
+
+
+  // 공통 요청
+  private ResultActions performRequest(MockHttpServletRequestBuilder builder, Object request)
+      throws Exception {
+    return mockMvc.perform(
+        builder
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(
+                objectMapper.writeValueAsString(request)) // 자바 객체를 JSON 문자열로 변환하여 CONTENT 에 넣기 위함.
+            .with(csrf()) // CSRF 토큰 포함 (Spring Security)
+    );
+  }
+  // .content 는 byte[] 타입 받는 메서드
+  // String 넘기면 내부에서 .getBytes() 처리한다.
+  // = 문자열, JSON, XML, 폼 데이터 전부 가능
+
+  // 문서화 파일 이름
+  public String generateDocName(String fieldName, String value) {
+    if (value == null) {
+      return fieldName + "-null";
+    }
+    if (value.isEmpty()) {
+      return fieldName + "-empty";
+    }
+    return fieldName + "-" + value.replaceAll("[^a-zA-Z0-9]", "-");
+  }
+}

--- a/src/test/java/com/clover/bookflow/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/clover/bookflow/domain/user/controller/UserControllerTest.java
@@ -1,5 +1,6 @@
 package com.clover.bookflow.domain.user.controller;
 
+import static com.clover.bookflow.common.ApiDocs.combineFields;
 import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
 import static com.epages.restdocs.apispec.ResourceSnippetParameters.builder;
@@ -7,23 +8,29 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.clover.bookflow.common.ApiDocs;
+import com.clover.bookflow.common.TestHelper;
 import com.clover.bookflow.domain.user.dto.request.UserSignupRequest;
 import com.clover.bookflow.domain.user.dto.response.UserSignupResponse;
+import com.clover.bookflow.domain.user.helper.UserTestHelper;
 import com.clover.bookflow.domain.user.service.UserService;
+import com.clover.bookflow.global.errorcode.UserErrorCode;
+import com.clover.bookflow.global.exception.DuplicateResourceException;
 import com.clover.bookflow.global.security.SecurityConfig;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.http.MediaType;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -35,13 +42,13 @@ import org.springframework.web.context.WebApplicationContext;
 // @WebMvcTest는 컨트롤러, 필터 등 웹 컴포넌트만 테스트하기 위한 어노테이션
 // - MockMvc를 자동 설정하기 위해 내부적으로 @AutoConfigureMockMvc 포함
 // - SecurityConfig는 명시적으로 @Import 필요
-@WebMvcTest(UserController.class)
+@WebMvcTest(UserController.class) // 컨트롤러만 스캔해서 스프링컨테이너에 등록
 @Import(SecurityConfig.class)
 @ExtendWith({RestDocumentationExtension.class, SpringExtension.class})
 public class UserControllerTest {
 
   @Autowired
-  MockMvc mockMvc;
+  private MockMvc mockMvc;
 
   @Autowired
   private ObjectMapper objectMapper;
@@ -61,6 +68,9 @@ public class UserControllerTest {
 
 //  private RestDocumentationResultHandler restDocs;
 
+  private UserTestHelper userTestHelper;
+  private TestHelper testHelper;
+
   @BeforeEach
   void setUp(RestDocumentationContextProvider provider) {
 //    this.restDocs = document("{class-name}/{method-name}"); // 문서 경로 설정 // 메서드마다 커스텀으로 변경
@@ -68,39 +78,259 @@ public class UserControllerTest {
         .apply(documentationConfiguration(provider)) // RestDocs 구성
 //        .alwaysDo(restDocs) // 문서 자동 생성
         .build();
+
+    testHelper = new TestHelper(mockMvc, objectMapper);
+    userTestHelper = new UserTestHelper();
   }
 
-  @DisplayName("회원가입을 요청하면 201 반환한다.")
-  @Test
-  void signup_success_201() throws Exception {
-    // given
-    UserSignupRequest request = new UserSignupRequest("hkd111@example.com", "password123", "길똥이");
-    UserSignupResponse response = new UserSignupResponse("hkd111@example.com", "길똥이");
+  @Nested
+  @DisplayName("회원가입")
+  class signup {
 
-    // when
-    given(userService.signup(any(UserSignupRequest.class))).willReturn(response);
+    @Nested
+    @DisplayName("성공")
+    class success {
 
-    // then
-    mockMvc.perform(post("/users/signup")
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(objectMapper.writeValueAsString(request))
-            .with(csrf())) // CSRF 토큰 포함 (Spring Security)
-        .andExpect(status().isCreated()) // HTTP 201 기대
-        .andDo(document("users/signup/success-201", // 문서 파일명
-            resource(builder()
-                .tag("User") // Swagger UI 태그
-                .summary("회원가입 API") // 간단 설명
-                .description("이메일, 비밀번호, 닉네임을 입력받아 회원가입을 처리합니다.")
-                .requestFields( // 요청 필드 설명
-                    fieldWithPath("email").description("사용자 이메일"),
-                    fieldWithPath("password").description("사용자 비밀번호"),
-                    fieldWithPath("nickname").description("사용자 닉네임")
+      @DisplayName("회원가입을 요청하면 201 반환한다.")
+      @Test
+      void signup_success_201() throws Exception {
+        // given
+        UserSignupRequest request = userTestHelper.createValidSignupRequest();
+        UserSignupResponse response = userTestHelper.createSignupResponse();
+
+        // when
+        given(userService.signup(any(UserSignupRequest.class))).willReturn(response);
+        // 여기 any 사용해도 request 는 mockMvc.perform 에 필요
+
+        // then
+        testHelper.postRequest("/users/signup", request)
+            .andExpect(status().isCreated()) // HTTP 201 기대
+            .andDo(document("users/signup/success-201", // 문서 파일명
+                resource(builder()
+                    .tag("User") // Swagger UI 태그
+                    .summary("회원가입 API") // 간단 설명
+                    .description("이메일, 비밀번호, 닉네임을 입력받아 회원가입을 처리합니다.")
+                    .requestFields( // 요청 필드 설명
+                        fieldWithPath("email").description("사용자 이메일"),
+                        fieldWithPath("password").description("사용자 비밀번호"),
+                        fieldWithPath("nickname").description("사용자 닉네임")
+                    )
+                    .responseFields(
+                        combineFields(
+                            ApiDocs.COMMON_FIELDS,
+                            fieldWithPath("data.email").description("회원 가입된 이메일"),
+                            fieldWithPath("data.nickname").description("회원 가입된 닉네임")
+                        )
+                    )
+                    .build()
                 )
-                .build()
-            )
-        ));
+            ));
+      }
+      // DispatcherServlet 통해 요청 흐름
+    }
+
+    @Nested
+    @DisplayName("실패")
+    class fail {
+
+      @ParameterizedTest
+      @CsvSource(
+          value = {
+              "null, 'Email must not be blank'",
+              "'', 'Email must not be blank'",
+              "'invalid-email', 'Invalid email format'"
+          },
+          nullValues = "null"
+      )
+      public void testEmailValidation(String email, String expectedErrorMessage) throws Exception {
+        // given
+        UserSignupRequest request = userTestHelper.createInvalidSignupRequest(email, "password123",
+            "길똥이");
+
+        // when & then
+        String documentName = testHelper.generateDocName("email", email);
+
+        testHelper.postRequest("/users/signup", request)
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.errors[0].message").value(expectedErrorMessage))
+            .andDo(document("users/signup/fail-400/email-validation-" + documentName,
+                resource(builder()
+                    .tag("User")
+                    .summary("회원가입 API")
+                    .description("이메일, 비밀번호, 닉네임을 입력받아 회원가입을 처리합니다.")
+                    .requestFields(
+                        fieldWithPath("email").description("사용자 이메일"),
+                        fieldWithPath("password").description("사용자 비밀번호"),
+                        fieldWithPath("nickname").description("사용자 닉네임")
+                    )
+                    .responseFields(
+                        combineFields(
+                            ApiDocs.COMMON_FIELDS,
+                            ApiDocs.ERROR_DETAIL_FIELDS
+                        )
+                    )
+                    .build()
+                )
+            ));
+      }
+
+      @ParameterizedTest
+      @CsvSource(
+          value = {
+              "null, 'Password must not be blank'",
+              "'          ', 'Password must not be blank'",
+              "'0', 'Password must be between 8 and 20 characters'",
+              "'abcdefghijklmnopqrstuvwxyz', 'Password must be between 8 and 20 characters'"
+          },
+          nullValues = "null"
+      )
+      public void testPasswordValidation(String password, String expectedErrorMessage)
+          throws Exception {
+        // given
+        UserSignupRequest request = userTestHelper.createInvalidSignupRequest("hkd111@example.com",
+            password, "길똥이");
+
+        // when & then
+        String documentName = testHelper.generateDocName("password", password);
+
+        testHelper.postRequest("/users/signup", request)
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.errors[0].message").value(expectedErrorMessage))
+            .andDo(document("users/signup/fail-400/password-validation-" + documentName,
+                resource(builder()
+                    .tag("User")
+                    .summary("회원가입 API")
+                    .description("이메일, 비밀번호, 닉네임을 입력받아 회원가입을 처리합니다.")
+                    .requestFields(
+                        fieldWithPath("email").description("사용자 이메일"),
+                        fieldWithPath("password").description("사용자 비밀번호"),
+                        fieldWithPath("nickname").description("사용자 닉네임")
+                    )
+                    .responseFields(
+                        combineFields(
+                            ApiDocs.COMMON_FIELDS,
+                            ApiDocs.ERROR_DETAIL_FIELDS
+                        )
+                    )
+                    .build()
+                )
+            ));
+      }
+
+      @ParameterizedTest
+      @CsvSource(
+          value = {
+              "null, 'Nickname must not be blank'",
+              "'  ', 'Nickname must not be blank'",
+              "'a', 'Nickname must be between 2 and 20 characters'",
+              "'abcdefghijklmnopqrstuvwxyz', 'Nickname must be between 2 and 20 characters'"
+          },
+          nullValues = "null"
+      )
+      public void testNicknameValidation(String nickname, String expectedErrorMessage)
+          throws Exception {
+        // given
+        UserSignupRequest request = userTestHelper.createInvalidSignupRequest("hkd111@example.com",
+            "password123", nickname);
+
+        // when & then
+        String documentName = testHelper.generateDocName("nickname", nickname);
+
+        testHelper.postRequest("/users/signup", request)
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.errors[0].message").value(expectedErrorMessage))
+            .andDo(document("users/signup/fail-400/nickname-validation-" + documentName,
+                resource(builder()
+                    .tag("User")
+                    .summary("회원가입 API")
+                    .description("이메일, 비밀번호, 닉네임을 입력받아 회원가입을 처리합니다.")
+                    .requestFields(
+                        fieldWithPath("email").description("사용자 이메일"),
+                        fieldWithPath("password").description("사용자 비밀번호"),
+                        fieldWithPath("nickname").description("사용자 닉네임")
+                    )
+                    .responseFields(
+                        combineFields(
+                            ApiDocs.COMMON_FIELDS,
+                            ApiDocs.ERROR_DETAIL_FIELDS
+                        )
+                    )
+                    .build()
+                )
+            ));
+      }
+
+      @DisplayName("이메일 중복이면 409를 반환한다.")
+      @Test
+      void signup_fail_409_when_duplicate_email() throws Exception {
+        // given
+        UserSignupRequest request = userTestHelper.createValidSignupRequest();
+
+        // when
+        given(userService.signup(request)).willThrow(
+            new DuplicateResourceException(UserErrorCode.EMAIL_ALREADY_EXISTS));
+
+        // then
+        testHelper.postRequest("/users/signup", request)
+            .andExpect(status().isConflict())
+            .andExpect(jsonPath("$.success").value(false))
+            .andExpect(jsonPath("$.code").value("EMAIL_ALREADY_EXISTS"))
+            .andExpect(jsonPath("$.message").value("이미 등록된 이메일입니다."))
+            .andDo(document("users/signup/fail-409/duplicate-email",
+                resource(builder()
+                    .tag("User")
+                    .summary("회원가입 API")
+                    .description("이메일, 비밀번호, 닉네임을 입력받아 회원가입을 처리합니다.")
+                    .requestFields(
+                        fieldWithPath("email").description("사용자 이메일"),
+                        fieldWithPath("password").description("사용자 비밀번호"),
+                        fieldWithPath("nickname").description("사용자 닉네임")
+                    )
+                    .responseFields(
+                        ApiDocs.COMMON_FIELDS
+                    )
+                    .build()
+                )
+            ));
+      }
+
+      @DisplayName("닉네임 중복이면 409를 반환한다.")
+      @Test
+      void signup_fail_409_when_duplicate_nickname() throws Exception {
+        // given
+        UserSignupRequest request = userTestHelper.createValidSignupRequest();
+
+        // when
+        given(userService.signup(request)).willThrow(
+            new DuplicateResourceException(UserErrorCode.NICKNAME_ALREADY_EXISTS));
+
+        // then
+        testHelper.postRequest("/users/signup", request)
+            .andExpect(status().isConflict())
+            .andExpect(jsonPath("$.success").value(false))
+            .andExpect(jsonPath("$.code").value("NICKNAME_ALREADY_EXISTS"))
+            .andExpect(jsonPath("$.message").value("이미 존재하는 닉네임입니다."))
+            .andDo(document("users/signup/fail-409/duplicate-nickname",
+                resource(builder()
+                    .tag("User")
+                    .summary("회원가입 API")
+                    .description("이메일, 비밀번호, 닉네임을 입력받아 회원가입을 처리합니다.")
+                    .requestFields(
+                        fieldWithPath("email").description("사용자 이메일"),
+                        fieldWithPath("password").description("사용자 비밀번호"),
+                        fieldWithPath("nickname").description("사용자 닉네임")
+                    )
+                    .responseFields(
+                        ApiDocs.COMMON_FIELDS
+                    )
+                    .build()
+                )
+            ));
+      }
+
+    }
+
   }
-  // DispatcherServlet 통해 요청 흐름
 
 
 }

--- a/src/test/java/com/clover/bookflow/domain/user/helper/UserTestHelper.java
+++ b/src/test/java/com/clover/bookflow/domain/user/helper/UserTestHelper.java
@@ -1,0 +1,20 @@
+package com.clover.bookflow.domain.user.helper;
+
+import com.clover.bookflow.domain.user.dto.request.UserSignupRequest;
+import com.clover.bookflow.domain.user.dto.response.UserSignupResponse;
+
+public class UserTestHelper {
+
+  public UserSignupRequest createValidSignupRequest() {
+    return new UserSignupRequest("hkd111@example.com", "password123", "길똥이");
+  }
+
+  public UserSignupRequest createInvalidSignupRequest(String email, String password, String name) {
+    return new UserSignupRequest(email, password, name);
+  }
+
+  public UserSignupResponse createSignupResponse() {
+    return new UserSignupResponse("hkd111@example.com", "길똥이");
+  }
+
+}

--- a/src/test/java/com/clover/bookflow/domain/user/integration/UserIntegrationTest.java
+++ b/src/test/java/com/clover/bookflow/domain/user/integration/UserIntegrationTest.java
@@ -7,8 +7,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.clover.bookflow.config.AbstractIntegrationTest;
 import com.clover.bookflow.domain.user.dto.request.UserSignupRequest;
+import com.clover.bookflow.domain.user.entity.User;
+import com.clover.bookflow.domain.user.repository.UserRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -20,21 +24,87 @@ import org.springframework.test.web.servlet.MockMvc;
 @AutoConfigureMockMvc
 public class UserIntegrationTest extends AbstractIntegrationTest {
 
+  // 단위테스트와 달리 통합테스트에서 필드 주입한 이유
+  // 이유1. 생성자 주입이 통합에서 큰 이점 없다.
+  // 통합테스트에서는 Spring 이 자동으로 모든 Bean 구성, 주입
+  // Mock 객체나 직접 주입할 필요 적음
+  // 생성자 주입의 장점(명확한 의존성, 불변성) 은 서비스/비즈니스 로직 쪽에서 훨씬 중요
+  // 2. 테스트 코드의 가독성과 단순화
+  // 생성자 만들고 this 할당보다 필드 주입이 더 간결, 덜 방해
+
   @Autowired
   private MockMvc mockMvc;
 
-  @DisplayName("회원가입 성공")
-  @Test
-  void signup_success() throws Exception {
-    UserSignupRequest request = new UserSignupRequest("hkd111@example.com", "password123", "길똥이");
-    mockMvc.perform(post("/users/signup")
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(new ObjectMapper().writeValueAsString(request))
-            .with(csrf())
-        )
-        .andExpect(status().isCreated())
-        .andExpect(jsonPath("$.email").value("hkd111@example.com"))
-        .andExpect(jsonPath("$.nickname").value("길똥이"));
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @Autowired
+  private UserRepository userRepository;
+
+  @BeforeEach
+  void clean() {
+    userRepository.deleteAll();
+  }
+
+  @Nested
+  @DisplayName("회원가입")
+  class signup {
+
+    @DisplayName("회원가입 성공")
+    @Test
+    void signup_success() throws Exception {
+      UserSignupRequest request = new UserSignupRequest("hkd111@example.com", "password123", "길똥이");
+      mockMvc.perform(post("/users/signup")
+              .contentType(MediaType.APPLICATION_JSON)
+              .content(objectMapper.writeValueAsString(request))
+              .with(csrf())
+          )
+          .andExpect(status().isCreated())
+          .andExpect(jsonPath("$.data.email").value("hkd111@example.com"))
+          .andExpect(jsonPath("$.data.nickname").value("길똥이"));
+    }
+
+    @DisplayName("회원가입 실패 - 중복 이메일로 요청")
+    @Test
+    void signup_duplicate_email_fail() throws Exception {
+      // given
+      userRepository.save(User.create("hkd111@example.com", "encodedPW", "길똥이"));
+
+      UserSignupRequest request = new UserSignupRequest("hkd111@example.com", "password123", "길똥이");
+
+      // when, then
+      mockMvc.perform(post("/users/signup")
+              .contentType(MediaType.APPLICATION_JSON)
+              .content(objectMapper.writeValueAsString(request))
+              .with(csrf())
+          )
+          .andExpect(status().isConflict())
+          .andExpect(jsonPath("$.success").value(false))
+          .andExpect(jsonPath("$.code").value("EMAIL_ALREADY_EXISTS"))
+          .andExpect(jsonPath("$.message").value("이미 등록된 이메일입니다."));
+    }
+
+    @DisplayName("회원가입 실패 - 중복 닉네임으로 요청")
+    @Test
+    void signup_duplicate_nickname_fail() throws Exception {
+      // given
+      userRepository.save(User.create("hkd111@example.com", "encodedPW", "길똥이"));
+
+      UserSignupRequest request = new UserSignupRequest("hkd222@example.com", "password123", "길똥이");
+
+      // when, then
+      mockMvc.perform(post("/users/signup")
+              .contentType(MediaType.APPLICATION_JSON)
+              .content(objectMapper.writeValueAsString(request))
+              .with(csrf())
+          )
+          .andExpect(status().isConflict())
+          .andExpect(jsonPath("$.success").value(false))
+          .andExpect(jsonPath("$.code").value("NICKNAME_ALREADY_EXISTS"))
+          .andExpect(jsonPath("$.message").value("이미 존재하는 닉네임입니다."));
+    }
+
+
   }
 
 


### PR DESCRIPTION
# [#6 ] 회원가입 컨트롤러 실패 테스트 작성 및 문서화

---

## 📌 개요
- UserController 테스트 및 API 문서화 기반 작업
- 테스트 유틸 및 문서화 공통 코드 도입
- 환경 설정 파일 및 시큐리티 설정 개선

---

## ✨ 주요 변경 사항

- UserController 테스트 및 문서화
  - 회원가입 실패 케이스 테스트 작성
  - 테스트 코드 리팩터링: `TestHelper`, `UserTestHelper` 도입
  - API 문서화 공통 클래스 추가: `ApiDocs` 

- 통합 테스트 작성
  - `UserIntegrationTest`: 회원가입 실패 케이스 통합 테스트 작성

- 환경 설정 및 보안 설정 개선
  - `UserSignRequest`: 유효성 메시지 수정
  - `SecurityConfig`: Swagger 문서 경로 허용 추가  
    (`/swagger-ui/**`, `/v3/api-docs/**`, `/docs/**`)
  - `application-dev.yml` 환경 설정 파일명 변경

---

## ✅ 테스트
- [x] `UserControllerTest`
- [x] `UserIntegrationTest`
- [x] API 문서 생성 확인

---

## 🎯 향후 작업 예정
- 로그인/인증 개발 및 문서화
- 비밀번호 커스텀 유효성 검사 로직 추가

---

## 🔗 관련 이슈
Related to #6 