### PR TITLE
[Refactor] 에러코드 리팩토링 및 공통 코드 분리

### DIFF
--- a/src/main/java/com/clover/bookflow/global/errorcode/CommonErrorCode.java
+++ b/src/main/java/com/clover/bookflow/global/errorcode/CommonErrorCode.java
@@ -1,0 +1,25 @@
+package com.clover.bookflow.global.errorcode;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum CommonErrorCode implements ErrorCode {
+
+  DUPLICATE_RESOURCE("COMMON_001", "이미 존재하는 리소스입니다.", HttpStatus.CONFLICT),
+  INVALID_INPUT("COMMON_002", "입력값이 잘못되었습니다.", HttpStatus.BAD_REQUEST),
+  UNAUTHORIZED("COMMON_003", "인증이 필요합니다.", HttpStatus.UNAUTHORIZED),
+  FORBIDDEN("COMMON_004", "접근 권한이 없습니다.", HttpStatus.FORBIDDEN),
+  INTERNAL_ERROR("COMMON_005", "서버 내부 오류입니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+
+  private final String code;
+  private final String message;
+  private final HttpStatus status;
+
+  CommonErrorCode(String code, String message, HttpStatus status) {
+    this.code = code;
+    this.message = message;
+    this.status = status;
+  }
+
+}

--- a/src/main/java/com/clover/bookflow/global/errorcode/ErrorCode.java
+++ b/src/main/java/com/clover/bookflow/global/errorcode/ErrorCode.java
@@ -4,10 +4,10 @@ import org.springframework.http.HttpStatus;
 
 public interface ErrorCode {
 
-  HttpStatus getStatus();
-
   String getCode();
 
   String getMessage();
+
+  HttpStatus getStatus();
 
 }

--- a/src/main/java/com/clover/bookflow/global/errorcode/UserErrorCode.java
+++ b/src/main/java/com/clover/bookflow/global/errorcode/UserErrorCode.java
@@ -1,34 +1,26 @@
 package com.clover.bookflow.global.errorcode;
 
+import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
+@Getter
 public enum UserErrorCode implements ErrorCode {
-  // User
-  EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "EMAIL_ALREADY_EXISTS", "이미 등록된 이메일입니다."),
-  NICKNAME_ALREADY_EXISTS(HttpStatus.CONFLICT, "NICKNAME_ALREADY_EXISTS", "이미 존재하는 닉네임입니다.");
 
-  private final HttpStatus status;
+  USER_NOT_FOUND("USER_001", "사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+  INVALID_USER_STATE("USER_002", "사용자 상태가 유효하지 않습니다.", HttpStatus.BAD_REQUEST),
+  PASSWORD_MISMATCH("USER_003", "비밀번호가 일치하지 않습니다.", HttpStatus.UNAUTHORIZED),
+
+  EMAIL_ALREADY_EXISTS("USER_004", "이미 등록된 이메일입니다.", HttpStatus.CONFLICT),
+  NICKNAME_ALREADY_EXISTS("USER_005", "이미 존재하는 닉네임입니다.", HttpStatus.CONFLICT);
+
   private final String code;
   private final String message;
+  private final HttpStatus status;
 
-  UserErrorCode(HttpStatus status, String code, String message) {
-    this.status = status;
+  UserErrorCode(String code, String message, HttpStatus status) {
     this.code = code;
     this.message = message;
+    this.status = status;
   }
 
-  @Override
-  public HttpStatus getStatus() {
-    return status;
-  }
-
-  @Override
-  public String getCode() {
-    return code;
-  }
-
-  @Override
-  public String getMessage() {
-    return message;
-  }
 }


### PR DESCRIPTION
# [#16 ] 에러코드 리팩토링 및 CommonErrorCode 생성

---

## 📌 개요
- 기존 에러코드 코드 체계 및 메시지 일관성 확보를 위한 수정 및 정리  
- 공통 에러코드를 `CommonErrorCode` enum으로 신규 통합 생성  
- 도메인별 에러코드와 공통 에러코드 분리하여 관리 체계 개선  
- 에러코드 관련 인터페이스 및 상위 타입 점검 및 개선

---

## ✨ 주요 변경 사항

- 에러코드 코드값 수정 및 네이밍 통일 작업  
- `CommonErrorCode` enum 생성 및 기존 공통 에러코드 이관  
- 기존 도메인별 에러코드(`UserErrorCode` 등)와 분리 관리 체계 적용  
- `ErrorCode` 인터페이스 및 관련 타입 점검 및 리팩토링 

---

## ✅ 테스트
- [x] 기존 도메인별 에러코드 관련 예외 테스트 정상 동작 확인  
- [x] 공통 에러코드 적용 후 예외 처리 정상 동작 확인

---

## 🎯 향후 작업 예정
- 다국어 메시지 지원을 위한 메시지 리소스 분리 작업

---

## 🔗 관련 이슈
Closed #16