### PR TITLE
[FEATURE] JpaAuditingConfig 추가 및 BaseTimeEntity 적용 관련 ControllerTest 문제 해결

### DIFF
--- a/src/main/java/com/clover/bookflow/config/JpaAuditingConfig.java
+++ b/src/main/java/com/clover/bookflow/config/JpaAuditingConfig.java
@@ -1,0 +1,10 @@
+package com.clover.bookflow.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+
+}

--- a/src/main/java/com/clover/bookflow/domain/auth/token/entity/RefreshToken.java
+++ b/src/main/java/com/clover/bookflow/domain/auth/token/entity/RefreshToken.java
@@ -2,6 +2,7 @@ package com.clover.bookflow.domain.auth.token.entity;
 
 import com.clover.bookflow.domain.auth.domain.TokenWithMeta;
 import com.clover.bookflow.domain.member.entity.Member;
+import com.clover.bookflow.global.common.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -20,7 +21,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "refresh_tokens")
-public class RefreshToken {
+public class RefreshToken extends BaseTimeEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/clover/bookflow/domain/member/entity/Member.java
+++ b/src/main/java/com/clover/bookflow/domain/member/entity/Member.java
@@ -2,6 +2,7 @@ package com.clover.bookflow.domain.member.entity;
 
 import com.clover.bookflow.domain.member.enums.MemberStatus;
 import com.clover.bookflow.domain.member.enums.Role;
+import com.clover.bookflow.global.common.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -20,7 +21,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "members")
-public class Member {
+public class Member extends BaseTimeEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/clover/bookflow/global/common/BaseTimeEntity.java
+++ b/src/main/java/com/clover/bookflow/global/common/BaseTimeEntity.java
@@ -1,0 +1,25 @@
+package com.clover.bookflow.global.common;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public abstract class BaseTimeEntity {
+
+  @CreatedDate
+  @Column(name = "created_at", nullable = false, updatable = false)
+  private LocalDateTime created;
+
+  @LastModifiedDate
+  @Column(name = "updated_at")
+  private LocalDateTime updatedDate;
+
+}


### PR DESCRIPTION
# [#38] JPA Auditing 설정 분리 및 슬라이스 테스트 오류 해결

---

## 📌 개요

`BaseTimeEntity` 적용 중, JPA Auditing이 활성화되지 않아  
슬라이스 테스트(`@WebMvcTest` 등) 실행 시 오류가 발생하는 문제를 해결하기 위해  
기존 Application 클래스에 있던 `@EnableJpaAuditing`을 분리하여  
별도의 `JpaAuditingConfig` 클래스로 이동 및 적용합니다.

---

## ✨ 주요 변경 사항

- `JpaAuditingConfig` 클래스 작성 및 `@EnableJpaAuditing` 적용  
- 기존 Application 클래스에서 `@EnableJpaAuditing` 제거  
- 슬라이스 테스트 환경에서 JPA 관련 빈 로딩 오류 방지를 위해 Auditing 설정 분리  
  - `@EnableJpaAuditing`이 프로젝트 최상단에 있으면 슬라이스 테스트에서 JPA 빈이 필요해져 오류 발생

---

## ✅ 테스트

- [x] 슬라이스 테스트(`@WebMvcTest`) 실행 시 JPA 관련 빈 로딩 오류 해소 확인

---

## 🔖 참고

- `JpaAuditingConfig`는 `config` 패키지에 위치
- 현재 시간 정보(`@CreatedDate`, `@LastModifiedDate`)만 사용하여 `AuditorAware` 구현은 생략  
- 향후 `@CreatedBy`, `@LastModifiedBy` 사용 시 `AuditorAware` 추가 예정  
- 공식 문서: [Spring Data JPA Auditing (3.4)](https://docs.spring.io/spring-data/jpa/reference/3.4/auditing.html)

---

## 🔗 관련 이슈

Closes #30
Closes #38
