### PR TITLE
[FEATURE] 관리자 도서 수집 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,8 @@ dependencies {
     implementation 'org.apache.commons:commons-lang3:3.18.0'
 
     implementation 'org.apache.commons:commons-text:1.10.0'
-    
+    implementation 'org.jsoup:jsoup:1.21.1'
+
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-security'
 
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
+    implementation 'org.apache.commons:commons-lang3:3.18.0'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.19.2'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-security'
 

--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,8 @@ dependencies {
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
     implementation 'org.apache.commons:commons-lang3:3.18.0'
 
+    implementation 'org.apache.commons:commons-text:1.10.0'
+    
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ ext {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-security'
 

--- a/src/main/java/com/clover/bookflow/config/RestClientConfig.java
+++ b/src/main/java/com/clover/bookflow/config/RestClientConfig.java
@@ -1,0 +1,18 @@
+package com.clover.bookflow.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+public class RestClientConfig {
+
+  @Bean
+  public RestClient restClient() {
+    // RestClient 인스턴스 커스터마이징
+    return RestClient.builder()
+        .baseUrl("https://www.aladin.co.kr/ttb/api")
+        .build();
+  }
+
+}

--- a/src/main/java/com/clover/bookflow/config/SchedulingConfig.java
+++ b/src/main/java/com/clover/bookflow/config/SchedulingConfig.java
@@ -1,0 +1,10 @@
+package com.clover.bookflow.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulingConfig {
+  
+}

--- a/src/main/java/com/clover/bookflow/config/SecurityConfig.java
+++ b/src/main/java/com/clover/bookflow/config/SecurityConfig.java
@@ -7,6 +7,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -20,6 +21,7 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
 

--- a/src/main/java/com/clover/bookflow/config/WebClientConfig.java
+++ b/src/main/java/com/clover/bookflow/config/WebClientConfig.java
@@ -1,0 +1,16 @@
+package com.clover.bookflow.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+
+  @Bean
+  public WebClient webClient() {
+    return WebClient.builder()
+        .baseUrl("https://www.nl.go.kr")
+        .build();
+  }
+}

--- a/src/main/java/com/clover/bookflow/domain/book/client/AladinApiClient.java
+++ b/src/main/java/com/clover/bookflow/domain/book/client/AladinApiClient.java
@@ -1,0 +1,41 @@
+package com.clover.bookflow.domain.book.client;
+
+import com.clover.bookflow.domain.book.dto.AladinResponseDto;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+@Component // 클라이언트 여기서 직접 생성하지 않고 설정 클래스나 자동 구성에서 미리 만든 것 주입 받아 사용
+public class AladinApiClient { // 실제 API 호출
+
+  private final RestClient restClient;
+
+  @Value("${aladin.ttbkey}")
+  private String ttbKey;
+
+  public AladinApiClient(RestClient restClient) {
+    this.restClient = restClient;
+  }
+
+  public AladinResponseDto fetchBestSellers() {
+    return restClient.get()
+        .uri(uriBuilder -> uriBuilder
+            .path("/ItemList.aspx")
+            .queryParam("ttbkey", ttbKey)
+            .queryParam("QueryType", "Bestseller")
+            .queryParam("MaxResults", 10)
+            .queryParam("start", 1)
+            .queryParam("SearchTarget", "Book")
+            .queryParam("Start", 1)
+            .queryParam("Cover", "MidBig")
+            .queryParam("Output", "JS")
+            .queryParam("Version", "20131101")
+            .queryParam("Year", 2024)
+            .queryParam("Month", 5)
+            .queryParam("Week", 1)
+            .build())
+        .retrieve()
+        .body(AladinResponseDto.class);
+  }
+
+}

--- a/src/main/java/com/clover/bookflow/domain/book/client/NationalLibraryApiClient.java
+++ b/src/main/java/com/clover/bookflow/domain/book/client/NationalLibraryApiClient.java
@@ -1,0 +1,59 @@
+package com.clover.bookflow.domain.book.client;
+
+import com.clover.bookflow.domain.book.dto.NationalLibraryResponseDto;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+
+@Component
+public class NationalLibraryApiClient {
+
+  private final WebClient webClient;
+
+  @Value("${nl.key}")
+  private String key;
+
+  public NationalLibraryApiClient(WebClient webClient) {
+    this.webClient = webClient;
+  }
+
+  public String fetchRecommendedBooks() {
+    return webClient.get()
+        .uri(uriBuilder -> uriBuilder
+            .path("NL/search/openApi/saseoApi.do")
+            .queryParam("Key", key)
+            .queryParam("startRowNumApi", 1)
+            .queryParam("endRowNumApi", 100)
+            .queryParam("start_date", "20240501")
+            .queryParam("end_date", "20240531")
+            .build())
+        .retrieve()
+        .bodyToMono(String.class)
+        .block();
+  }
+
+  public NationalLibraryResponseDto fetchBookDetail(String isbn) {
+    return webClient.get()
+        .uri(uriBuilder -> uriBuilder
+            .path("/seoji/SearchApi.do")
+            .queryParam("cert_key", key)
+            .queryParam("result_style", "json")
+            .queryParam("page_no", "1")
+            .queryParam("page_size", "10")
+            .queryParam("isbn", isbn).build())
+        .retrieve().bodyToMono(NationalLibraryResponseDto.class).block();
+  }
+
+
+  public String fetchBookDetailString(String isbn) {
+    return webClient.get()
+        .uri(uriBuilder -> uriBuilder
+            .queryParam("cert_key", key)
+            .queryParam("result_style", "json")
+            .queryParam("page_no", "1")
+            .queryParam("page_size", "10")
+            .queryParam("isbn", isbn).build())
+        .retrieve().bodyToMono(String.class).block();
+  }
+}

--- a/src/main/java/com/clover/bookflow/domain/book/controller/AdminBookController.java
+++ b/src/main/java/com/clover/bookflow/domain/book/controller/AdminBookController.java
@@ -1,0 +1,37 @@
+package com.clover.bookflow.domain.book.controller;
+
+import com.clover.bookflow.domain.book.service.AdminBookIngestService;
+import com.clover.bookflow.global.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/admin/book")
+@RequiredArgsConstructor
+public class AdminBookController { // 관리 배치용
+
+  // db 구축
+  // 태깅 요청
+  private final AdminBookIngestService adminBookIngestService;
+
+  @PreAuthorize("hasRole('ADMIN')")
+  @GetMapping("/ingest-bestsellers")
+  public ResponseEntity<ApiResponse<String>> ingestBestSellers() {
+    // bookadminserivce 에서 apiservice -> apiclient 호출?
+    adminBookIngestService.ingestBestSellers();
+    return ResponseEntity.ok().body(ApiResponse.success("베스트셀러 도서가 정상적으로 적재되었습니다."));
+  }
+
+  @PreAuthorize("hasRole('ADMIN')")
+  @GetMapping("/ingest-recommended")
+  public ResponseEntity<ApiResponse<String>> ingestRecommended() {
+    adminBookIngestService.ingestRecommendedBooks();
+    return ResponseEntity.ok().body(ApiResponse.success("추천 도서가 정상적으로 적재되었습니다."));
+  }
+
+
+}

--- a/src/main/java/com/clover/bookflow/domain/book/dto/AladinResponseDto.java
+++ b/src/main/java/com/clover/bookflow/domain/book/dto/AladinResponseDto.java
@@ -1,0 +1,65 @@
+package com.clover.bookflow.domain.book.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.LocalDate;
+import java.util.List;
+
+public record AladinResponseDto(
+    String version,
+    String logo,
+    String title,
+    String link,
+    String pubDate,
+    int totalResults,
+    int startIndex,
+    int itemsPerPage,
+    String query,
+    int searchCategoryId,
+    String searchCategoryName,
+
+    @JsonProperty("item")
+    List<Item> items
+) {
+
+  public record Item(
+      String title,
+      String link,
+      String author,
+      LocalDate pubDate,
+      String description,
+      String isbn,
+      String isbn13,
+      long itemId,
+      int priceSales,
+      int priceStandard,
+      String mallType,
+      String stockStatus,
+      int mileage,
+      String cover,
+      int categoryId,
+      String categoryName,
+      String publisher,
+      int salesPoint,
+      boolean adult,
+      boolean fixedPrice,
+      int customerReviewRank,
+      String bestDuration,
+      int bestRank,
+      SeriesInfo seriesInfo,
+      SubInfo subInfo
+  ) {
+
+  }
+
+  public record SeriesInfo(
+      long seriesId,
+      String seriesLink,
+      String seriesName
+  ) {
+
+  }
+
+  public record SubInfo() {
+
+  }
+}

--- a/src/main/java/com/clover/bookflow/domain/book/dto/BookAllSaveRequestDto.java
+++ b/src/main/java/com/clover/bookflow/domain/book/dto/BookAllSaveRequestDto.java
@@ -1,0 +1,34 @@
+package com.clover.bookflow.domain.book.dto;
+
+import com.clover.bookflow.domain.book.entity.Book;
+import com.clover.bookflow.domain.book.entity.BookDetail;
+import java.time.LocalDate;
+
+public record BookAllSaveRequestDto(
+    String drCode,
+    String drCodeName,
+    String recomtitle,
+    String recomauthor,
+    String recompublisher,
+    String recomisbn,
+    String recomfilepath,
+    String recommokcha,
+    String recomcontens,
+    String publishYear,
+    String mokchFilePath
+
+) {
+
+  public Book toEntity() {
+    LocalDate publishDate = LocalDate.parse(publishYear + "-01-01");
+    Book book = new Book(recomisbn, recomtitle, recomauthor, recompublisher, recomfilepath,
+        publishDate, null, drCodeName);
+    BookDetail bookDetail = new BookDetail(book);
+    bookDetail.updateDetail(null, drCode, mokchFilePath, recommokcha, null, null, null,
+        recomcontens, drCode, null);
+    book.changeBookDetail(bookDetail);
+    return book;
+  }
+
+
+}

--- a/src/main/java/com/clover/bookflow/domain/book/dto/BookClassificationDto.java
+++ b/src/main/java/com/clover/bookflow/domain/book/dto/BookClassificationDto.java
@@ -1,0 +1,15 @@
+package com.clover.bookflow.domain.book.dto;
+
+import java.util.Set;
+
+public record BookClassificationDto(
+    Set<BookSaveRequestDto> existing,
+    Set<BookSaveRequestDto> notExisting
+) {
+
+  public static BookClassificationDto of(Set<BookSaveRequestDto> existing,
+      Set<BookSaveRequestDto> notExisting) {
+    return new BookClassificationDto(existing, notExisting);
+  }
+
+}

--- a/src/main/java/com/clover/bookflow/domain/book/dto/BookDetailSaveRequestDto.java
+++ b/src/main/java/com/clover/bookflow/domain/book/dto/BookDetailSaveRequestDto.java
@@ -1,0 +1,49 @@
+package com.clover.bookflow.domain.book.dto;
+
+import com.clover.bookflow.domain.book.entity.Book;
+import com.clover.bookflow.domain.book.entity.BookDetail;
+import com.clover.bookflow.domain.book.enums.BookDetailStatus;
+
+public record BookDetailSaveRequestDto(
+    String eaIsbn,
+    String ddc,
+    String kdc,
+    String bookTbCntUrl,
+    String bookTbCnt,
+    String bookIntroductionUrl,
+    String bookIntroduction,
+    String bookSummaryUrl,
+    String bookSummary,
+    String subject,
+    String page,
+    BookDetailStatus status
+) {
+
+  public static BookDetailSaveRequestDto noDetail(String isbn) {
+    return new BookDetailSaveRequestDto(isbn, null, null, null, null, null, null, null, null, null,
+        null, BookDetailStatus.NO_DETAIL);
+  }
+
+  public static BookDetailSaveRequestDto error(String isbn) {
+    return new BookDetailSaveRequestDto(isbn, null, null, null, null, null, null, null, null, null,
+        null, BookDetailStatus.ERROR);
+  }
+
+  public static BookDetailSaveRequestDto complete(String isbn, String ddc, String kdc,
+      String bookTbCntUrl, String bookTbCnt, String bookIntroductionUrl, String bookIntroduction,
+      String bookSummaryUrl, String bookSummary, String subject, String page) {
+    return new BookDetailSaveRequestDto(isbn, ddc, kdc, bookTbCntUrl, bookTbCnt,
+        bookIntroductionUrl, bookIntroduction, bookSummaryUrl, bookSummary, subject, page,
+        BookDetailStatus.COMPLETE);
+  }
+
+  public BookDetail toEntity(Book book) {
+    BookDetail bookDetail = new BookDetail(book);
+    bookDetail.updateDetail(ddc, kdc, bookTbCntUrl, bookTbCnt, bookIntroductionUrl,
+        bookIntroduction, bookSummaryUrl, bookSummary, subject, page);
+    bookDetail.changeStatus(status);
+    return bookDetail;
+  }
+
+
+}

--- a/src/main/java/com/clover/bookflow/domain/book/dto/BookSaveRequestDto.java
+++ b/src/main/java/com/clover/bookflow/domain/book/dto/BookSaveRequestDto.java
@@ -1,0 +1,21 @@
+package com.clover.bookflow.domain.book.dto;
+
+import com.clover.bookflow.domain.book.entity.Book;
+import java.time.LocalDate;
+
+public record BookSaveRequestDto(
+    String isbn,
+    String title,
+    String author,
+    String publisher,
+    String coverImgUrl,
+    LocalDate publishedDate,
+    String description,
+    String category
+) {
+
+  public Book toEntity() {
+    return new Book(isbn, title, author, publisher, coverImgUrl, publishedDate, description,
+        category);
+  }
+}

--- a/src/main/java/com/clover/bookflow/domain/book/dto/NatLibRecResponseDto.java
+++ b/src/main/java/com/clover/bookflow/domain/book/dto/NatLibRecResponseDto.java
@@ -1,0 +1,96 @@
+package com.clover.bookflow.domain.book.dto;
+
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@JacksonXmlRootElement(localName = "channel")
+public class NatLibRecResponseDto {
+
+  @JacksonXmlProperty(localName = "totalCount")
+  private int totalCount;
+
+  // 여러 개의 <list> 요소를 리스트로 받기 (useWrapping=false 중요!)
+  @JacksonXmlElementWrapper(useWrapping = false)
+  @JacksonXmlProperty(localName = "list")
+  private List<ListItem> list;
+
+  @Getter
+  @Setter
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class ListItem {
+
+    @JacksonXmlProperty(localName = "item")
+    private Item item;
+
+  }
+
+  @Getter
+  @Setter
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class Item {
+
+    @JacksonXmlProperty(localName = "recomNo")
+    private String recomNo;
+
+    @JacksonXmlProperty(localName = "drCode")
+    private String drCode;
+
+    @JacksonXmlProperty(localName = "drCodeName")
+    private String drCodeName;
+
+    @JacksonXmlProperty(localName = "recomtitle")
+    private String recomtitle;
+
+    @JacksonXmlProperty(localName = "recomauthor")
+    private String recomauthor;
+
+    @JacksonXmlProperty(localName = "recompublisher")
+    private String recompublisher;
+
+    @JacksonXmlProperty(localName = "recomcallno")
+    private String recomcallno;
+
+    @JacksonXmlProperty(localName = "recomisbn")
+    private String recomisbn;
+
+    @JacksonXmlProperty(localName = "recomfilepath")
+    private String recomfilepath;
+
+    @JacksonXmlProperty(localName = "recommokcha")
+    private String recommokcha;
+
+    @JacksonXmlProperty(localName = "recomcontens")
+    private String recomcontens;
+
+    @JacksonXmlProperty(localName = "regdate")
+    private String regdate;
+
+    @JacksonXmlProperty(localName = "controlNo")
+    private String controlNo;
+
+    @JacksonXmlProperty(localName = "publishYear")
+    private String publishYear;
+
+    @JacksonXmlProperty(localName = "recomYear")
+    private String recomYear;
+
+    @JacksonXmlProperty(localName = "recomMonth")
+    private String recomMonth;
+
+    @JacksonXmlProperty(localName = "mokchFilePath")
+    private String mokchFilePath;
+  }
+}

--- a/src/main/java/com/clover/bookflow/domain/book/dto/NationalLibraryResponseDto.java
+++ b/src/main/java/com/clover/bookflow/domain/book/dto/NationalLibraryResponseDto.java
@@ -1,0 +1,55 @@
+package com.clover.bookflow.domain.book.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+public record NationalLibraryResponseDto(
+    @JsonProperty("TOTAL_COUNT") String totalCount,
+    @JsonProperty("PAGE_NO") String pageNo,
+    @JsonProperty("docs") List<Doc> docs
+) {
+
+  public record Doc(
+      @JsonProperty("PUBLISHER") String publisher,
+      @JsonProperty("DDC") String ddc,
+      @JsonProperty("UPDATE_DATE") String updateDate,
+      @JsonProperty("EA_ADD_CODE") String eaAddCode,
+      @JsonProperty("PUBLISHER_URL") String publisherUrl,
+      @JsonProperty("AUTHOR") String author,
+      @JsonProperty("SERIES_TITLE") String seriesTitle,
+      @JsonProperty("KDC") String kdc,
+      @JsonProperty("EDITION_STMT") String editionStmt,
+      @JsonProperty("BOOK_TB_CNT_URL") String bookTbCntUrl,
+      @JsonProperty("BOOK_TB_CNT") String bookTbCnt,
+      @JsonProperty("BOOK_INTRODUCTION_URL") String bookIntroductionUrl,
+      @JsonProperty("BOOK_INTRODUCTION") String bookIntroduction,
+      @JsonProperty("BOOK_SUMMARY_URL") String bookSummaryUrl,
+      @JsonProperty("BOOK_SUMMARY") String bookSummary,
+      @JsonProperty("TITLE_URL") String titleUrl,
+      @JsonProperty("SET_ISBN") String setIsbn,
+      @JsonProperty("REAL_PUBLISH_DATE") String realPublishDate,
+      @JsonProperty("PRE_PRICE") String prePrice,
+      @JsonProperty("DEPOSIT_YN") String depositYn,
+      @JsonProperty("BOOK_SIZE") String bookSize,
+      @JsonProperty("EBOOK_YN") String ebookYn,
+      @JsonProperty("REAL_PRICE") String realPrice,
+      @JsonProperty("FORM") String form,
+      @JsonProperty("CONTROL_NO") String controlNo,
+      @JsonProperty("SERIES_NO") String seriesNo,
+      @JsonProperty("EA_ISBN") String eaIsbn,
+      @JsonProperty("INPUT_DATE") String inputDate,
+      @JsonProperty("SET_EXPRESSION") String setExpression,
+      @JsonProperty("VOL") String vol,
+      @JsonProperty("CIP_YN") String cipYn,
+      @JsonProperty("SUBJECT") String subject,
+      @JsonProperty("BIB_YN") String bibYn,
+      @JsonProperty("TITLE") String title,
+      @JsonProperty("PUBLISH_PREDATE") String publishPredate,
+      @JsonProperty("SET_ADD_CODE") String setAddCode,
+      @JsonProperty("PAGE") String page,
+      @JsonProperty("RELATED_ISBN") String relatedIsbn,
+      @JsonProperty("FORM_DETAIL") String formDetail
+  ) {
+
+  }
+}

--- a/src/main/java/com/clover/bookflow/domain/book/entity/Book.java
+++ b/src/main/java/com/clover/bookflow/domain/book/entity/Book.java
@@ -1,0 +1,70 @@
+package com.clover.bookflow.domain.book.entity;
+
+import com.clover.bookflow.global.common.BaseTimeEntity;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "books")
+public class Book extends BaseTimeEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  private String isbn;
+
+  private String title;
+
+  private String author;
+
+  private String publisher;
+
+  private String coverImgUrl;
+
+  private LocalDate publishedDate;
+
+  @Lob
+  private String shortDescription;
+
+  private String category;
+
+
+  @OneToOne(mappedBy = "book", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+  private BookDetail bookDetail;
+
+  public Book(String isbn, String title, String author, String publisher, String coverImgUrl,
+      LocalDate publishedDate, String shortDescription, String category) {
+    this.isbn = isbn;
+    this.title = title;
+    this.author = author;
+    this.publisher = publisher;
+    this.coverImgUrl = coverImgUrl;
+    this.publishedDate = publishedDate;
+    this.shortDescription = shortDescription;
+    this.category = category;
+  }
+
+  public void changeBookDetail(BookDetail bookDetail) {
+    this.bookDetail = bookDetail;
+    if (bookDetail.getBook() != this) {
+      bookDetail.changeBook(this);
+    }
+  }
+
+}
+
+

--- a/src/main/java/com/clover/bookflow/domain/book/entity/BookDetail.java
+++ b/src/main/java/com/clover/bookflow/domain/book/entity/BookDetail.java
@@ -1,0 +1,108 @@
+package com.clover.bookflow.domain.book.entity;
+
+import com.clover.bookflow.domain.book.enums.BookDetailStatus;
+import com.clover.bookflow.global.common.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
+import jakarta.persistence.MapsId;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "book_detail")
+public class BookDetail extends BaseTimeEntity {
+
+  @Id
+  private Long id;
+
+  @MapsId
+  @OneToOne
+  @JoinColumn(name = "book_id")
+  private Book book;
+
+  private String ddc;
+
+  private String kdc;
+
+  private String bookTbCntUrl; // 목차 URL
+
+  @Lob
+  private String bookTbCnt;
+
+  private String bookIntroductionUrl; // 책소개 URL
+
+  @Lob
+  private String bookIntroduction;
+
+  private String bookSummaryUrl; // 책요약 URL
+
+  @Lob
+  private String bookSummary;
+
+  private String subject;
+
+  private String pageCount;
+
+  // 적재 진행 상태 status Book 저장 시 기본값 적재 전.
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private BookDetailStatus status;
+
+  private Integer retryCount;
+
+  private String lastErrorMessage;
+
+  private LocalDateTime lastTriedAt;
+
+  public BookDetail(Book book) {
+    this.book = book;
+    this.status = BookDetailStatus.READY;
+    this.retryCount = 0;
+  }
+
+  public void changeBook(Book book) {
+    this.book = book;
+    if (book.getBookDetail() != this) {
+      book.changeBookDetail(this);
+    }
+  }
+
+  public void updateDetail(String ddc, String kdc, String bookTbCntUrl, String bookTbCnt,
+      String bookIntroductionUrl, String bookIntroduction, String bookSummaryUrl,
+      String bookSummary, String subject, String pageCount) {
+    this.ddc = ddc;
+    this.kdc = kdc;
+    this.bookTbCntUrl = bookTbCntUrl;
+    this.bookTbCnt = bookTbCnt;
+    this.bookIntroductionUrl = bookIntroductionUrl;
+    this.bookIntroduction = bookIntroduction;
+    this.bookSummaryUrl = bookSummaryUrl;
+    this.bookSummary = bookSummary;
+    this.subject = subject;
+    this.pageCount = pageCount;
+  }
+
+  public void changeStatus(BookDetailStatus status) {
+    this.status = status;
+  }
+
+  public void incrementRetryCount() {
+    if (this.retryCount == null) {
+      this.retryCount = 0;
+    }
+    this.retryCount++;
+  }
+
+
+}

--- a/src/main/java/com/clover/bookflow/domain/book/enums/BookDetailStatus.java
+++ b/src/main/java/com/clover/bookflow/domain/book/enums/BookDetailStatus.java
@@ -1,0 +1,10 @@
+package com.clover.bookflow.domain.book.enums;
+
+public enum BookDetailStatus {
+  READY, // 적재 대기 (book 생성 시)
+  PROCESSING, // 적재 시도 중 (큐에 넣었거나 워커가 처리 중)
+  COMPLETE, // 상세 적재 성공
+  NO_DETAIL, // 상세 데이터 없음
+  ERROR, // 오류 발생
+  FAILED // 재시도 후 실패 확정
+}

--- a/src/main/java/com/clover/bookflow/domain/book/repository/BookDetailRepository.java
+++ b/src/main/java/com/clover/bookflow/domain/book/repository/BookDetailRepository.java
@@ -1,0 +1,16 @@
+package com.clover.bookflow.domain.book.repository;
+
+import com.clover.bookflow.domain.book.entity.BookDetail;
+import com.clover.bookflow.domain.book.enums.BookDetailStatus;
+import java.util.Set;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface BookDetailRepository extends JpaRepository<BookDetail, Long> {
+
+  @Query("SELECT b.book.isbn FROM BookDetail b WHERE b.book.isbn IN :isbns AND b.status = :status")
+  Set<String> findByIsbnsAndStatus(@Param("isbns") Set<String> isbns,
+      @Param("status") BookDetailStatus status);
+
+}

--- a/src/main/java/com/clover/bookflow/domain/book/repository/BookRepository.java
+++ b/src/main/java/com/clover/bookflow/domain/book/repository/BookRepository.java
@@ -1,0 +1,16 @@
+package com.clover.bookflow.domain.book.repository;
+
+import com.clover.bookflow.domain.book.entity.Book;
+import java.util.Optional;
+import java.util.Set;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface BookRepository extends JpaRepository<Book, Long> {
+
+  @Query("SELECT b.isbn FROM Book b WHERE b.isbn IN :isbns")
+  Set<String> findExistingIsbns(@Param("isbns") Set<String> isbns);
+
+  Optional<Book> findByIsbn(String isbn);
+}

--- a/src/main/java/com/clover/bookflow/domain/book/service/AdminBookIngestService.java
+++ b/src/main/java/com/clover/bookflow/domain/book/service/AdminBookIngestService.java
@@ -1,0 +1,111 @@
+package com.clover.bookflow.domain.book.service;
+
+import com.clover.bookflow.domain.book.dto.BookAllSaveRequestDto;
+import com.clover.bookflow.domain.book.dto.BookClassificationDto;
+import com.clover.bookflow.domain.book.dto.BookSaveRequestDto;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AdminBookIngestService {
+
+  private final AladinApiService aladinApiService;
+
+  private final NationalLibraryApiService nationalLibraryApiService;
+
+  private final BookService bookService;
+
+  private final BookDetailService bookDetailService;
+
+  // 도서 데이터 저장
+  // Todo: 스케줄러 적용
+  public void ingestRecommendedBooks() { // NatLib
+
+    List<BookAllSaveRequestDto> books = nationalLibraryApiService.fetchRecommendedBooks();
+
+    // 중복, complete 제거
+
+    bookService.saveBooksWithDetails(books);
+
+  }
+
+  public void ingestBestSellers() { // Aladin
+    // 목록 저장용 api 호출
+    // Book 에 없는 도서 필터링 -> Book 저장, BookDetail 저장
+    // Book 에 있는 도서 && Complete 아닌 도서 필터링 -> BookDetail 저장
+
+    List<BookSaveRequestDto> books = aladinApiService.fetchBestSellers();
+
+    // 기본 호출된 목록 내 중복 제거 - 도서 등록 사용자가 안함. 중복 제거 관리자 몫
+
+    // isbn 기준 Book 에 존재 유무 기준 분류
+    BookClassificationDto filteredBooks = classifyBooksByExistence(books);
+    // Book 에 없는 도서 필터링
+    // 저장
+    // 도서 데이터 저장
+    bookService.saveBasicBooks(filteredBooks.notExisting());
+
+    // Todo: 도서 상세 정보 데이터 미비 추후 보완 고려해서 보충
+//    // Book 에 있지만 Complete 아닌 도서 필터링
+//    // BookDetail 저장
+//    List<BookSaveRequestDto> notCompletedBooks = removeCompletedBooks(filteredBooks.existing());
+//
+//    // notExisting, existingButNotComplete 둘 다 호출
+//    List<BookSaveRequestDto> result = new ArrayList<>(filteredBooks.notExisting());
+//    result.addAll(notCompletedBooks);
+//
+//    // 상세 정보 저장
+//    // Book 에 없는 도서와 Book 에 있지만 Complete 아닌 도서
+//    List<BookDetailSaveRequestDto> details = nationalLibraryApiService.fetchBookDetails(
+//        result);
+//
+//    bookService.saveBookDetails(details);
+  }
+
+  // Todo: filter 필요 시
+  private BookClassificationDto classifyBooksByExistence(List<BookSaveRequestDto> books) {
+    Set<String> isbns = books.stream()
+        .map(BookSaveRequestDto::isbn)
+        .collect(Collectors.toSet());
+
+    log.info("수신된 ISBN 목록: {}", isbns);
+
+    Set<String> existingIsbns = bookService.findExistingIsbns(isbns);
+    log.info("이미 존재하는 ISBN 목록: {}", existingIsbns);
+
+    Map<Boolean, List<BookSaveRequestDto>> partitioned = books.stream()
+        .collect(Collectors.partitioningBy(book -> existingIsbns.contains(book.isbn())));
+
+    Set<BookSaveRequestDto> existingBooks = new HashSet<>(partitioned.get(true));
+    Set<BookSaveRequestDto> notExistingBooks = new HashSet<>(partitioned.get(false));
+
+    return BookClassificationDto.of(existingBooks, notExistingBooks);
+  }
+
+
+  // Todo: removeDuplicate
+  private List<BookSaveRequestDto> removeCompletedBooks(Set<BookSaveRequestDto> books) {
+    Set<String> completeIsbns = bookDetailService.findCompletedIsbns(
+        books.stream().map(BookSaveRequestDto::isbn).collect(Collectors.toSet()));
+    log.info("완료된 ISBN 목록: {}", completeIsbns);
+
+    List<BookSaveRequestDto> filtered = books.stream()
+        .filter(book -> !completeIsbns.contains(book.isbn()))
+        .toList();
+
+    log.info("중복 제거 후 남은 도서 수: {}", filtered.size());
+    log.debug("남은 도서 ISBN: {}", filtered.stream().map(BookSaveRequestDto::isbn).toList());
+
+    return filtered;
+
+  }
+
+}

--- a/src/main/java/com/clover/bookflow/domain/book/service/AladinApiService.java
+++ b/src/main/java/com/clover/bookflow/domain/book/service/AladinApiService.java
@@ -1,0 +1,47 @@
+package com.clover.bookflow.domain.book.service;
+
+import com.clover.bookflow.domain.book.client.AladinApiClient;
+import com.clover.bookflow.domain.book.dto.AladinResponseDto;
+import com.clover.bookflow.domain.book.dto.BookSaveRequestDto;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AladinApiService { //  클라이언트 호출 + 로직 + 예외 처리
+  // 외부 내부 매핑
+
+  private final AladinApiClient aladinApiClient;
+
+  // Todo: 검색 (모든 도서 db 사전 저장은 한계 있다. db 에 없는 도서 검색 api 호출 후 개별 도서 저장 로직 구현)
+
+
+  // 베스트셀러 리스트
+  public List<BookSaveRequestDto> fetchBestSellers() {
+    AladinResponseDto response = aladinApiClient.fetchBestSellers();
+
+    if (response == null || response.items() == null || response.items().isEmpty()) {
+      throw new RuntimeException("알라딘 응답이 비어있습니다.");
+    }
+
+    // 응답 변환 도서리스트
+    return response.items().stream()
+        .map(item -> new BookSaveRequestDto(
+            item.isbn13(),
+            item.title(),
+            item.author(),
+            item.publisher(),
+            item.cover(),
+            item.pubDate(),
+            item.description(),
+            item.categoryName()
+        ))
+        .toList();
+
+  }
+
+
+}

--- a/src/main/java/com/clover/bookflow/domain/book/service/BookDetailService.java
+++ b/src/main/java/com/clover/bookflow/domain/book/service/BookDetailService.java
@@ -1,0 +1,25 @@
+package com.clover.bookflow.domain.book.service;
+
+import com.clover.bookflow.domain.book.enums.BookDetailStatus;
+import com.clover.bookflow.domain.book.repository.BookDetailRepository;
+import java.util.Collections;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class BookDetailService {
+
+  private final BookDetailRepository bookDetailRepository;
+
+  public Set<String> findCompletedIsbns(Set<String> isbns) {
+    if (isbns == null || isbns.isEmpty()) {
+      return Collections.emptySet();
+    }
+    return bookDetailRepository.findByIsbnsAndStatus(isbns, BookDetailStatus.COMPLETE);
+  }
+
+}

--- a/src/main/java/com/clover/bookflow/domain/book/service/BookService.java
+++ b/src/main/java/com/clover/bookflow/domain/book/service/BookService.java
@@ -1,0 +1,106 @@
+package com.clover.bookflow.domain.book.service;
+
+import com.clover.bookflow.domain.book.dto.BookAllSaveRequestDto;
+import com.clover.bookflow.domain.book.dto.BookDetailSaveRequestDto;
+import com.clover.bookflow.domain.book.dto.BookSaveRequestDto;
+import com.clover.bookflow.domain.book.entity.Book;
+import com.clover.bookflow.domain.book.entity.BookDetail;
+import com.clover.bookflow.domain.book.repository.BookDetailRepository;
+import com.clover.bookflow.domain.book.repository.BookRepository;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class BookService {
+
+  private final BookRepository bookRepository;
+
+  private final BookDetailRepository bookDetailRepository;
+  // Todo : 상품 리스트 - 베스트셀러 조회
+
+  // 책 crud
+
+  // 도서 저장
+  @Transactional
+  public void saveBooksWithDetails(List<BookAllSaveRequestDto> books) {
+    List<Book> entities = books.stream().map(BookAllSaveRequestDto::toEntity).toList();
+
+    bookRepository.saveAll(entities);
+
+    log.info("Saved {} books with details", entities.size());
+
+  }
+
+  @Transactional
+  public void saveBasicBooks(Set<BookSaveRequestDto> books) {
+    // 도서 저장
+    List<Book> entities = books.stream()
+        .map(BookSaveRequestDto::toEntity).toList();
+
+    bookRepository.saveAll(entities);
+
+    List<BookDetail> details = entities.stream()
+        .map(BookDetail::new)
+        .toList();
+
+    bookDetailRepository.saveAll(details);
+    log.info("Saved {} books", entities.size());
+  }
+
+  @Transactional
+  public void saveBookDetails(List<BookDetailSaveRequestDto> docs) {
+    // 비동기
+    List<BookDetail> details = new ArrayList<>();
+    for (BookDetailSaveRequestDto doc : docs) {
+      Optional<Book> book = bookRepository.findByIsbn(doc.eaIsbn());
+      if (book.isEmpty()) {
+        continue;
+      }
+      Optional<BookDetail> existingDetailOpt = bookDetailRepository.findById(book.get().getId());
+
+      BookDetail bookDetail;
+
+      if (existingDetailOpt.isPresent()) {
+        bookDetail = existingDetailOpt.get();
+        bookDetail.updateDetail(
+            doc.ddc(),
+            doc.kdc(),
+            doc.bookTbCntUrl(),
+            doc.bookTbCnt(),
+            doc.bookIntroductionUrl(),
+            doc.bookIntroduction(),
+            doc.bookSummaryUrl(),
+            doc.bookSummary(),
+            doc.subject(),
+            doc.page()
+        );
+        bookDetail.changeStatus(doc.status());
+      } else {
+        bookDetail = doc.toEntity(book.get());
+      }
+      details.add(bookDetail);
+    }
+    bookDetailRepository.saveAll(details);
+    log.info("Saved {} book details", details.size());
+  }
+
+
+  public Set<String> findExistingIsbns(Set<String> isbns) {
+    if (isbns == null || isbns.isEmpty()) {
+      return Collections.emptySet();
+    }
+
+    return bookRepository.findExistingIsbns(isbns);
+  }
+
+  // 도서 조회
+}

--- a/src/main/java/com/clover/bookflow/domain/book/service/NationalLibraryApiService.java
+++ b/src/main/java/com/clover/bookflow/domain/book/service/NationalLibraryApiService.java
@@ -1,0 +1,116 @@
+package com.clover.bookflow.domain.book.service;
+
+import com.clover.bookflow.domain.book.client.NationalLibraryApiClient;
+import com.clover.bookflow.domain.book.dto.BookAllSaveRequestDto;
+import com.clover.bookflow.domain.book.dto.NatLibRecResponseDto;
+import com.clover.bookflow.domain.book.dto.NatLibRecResponseDto.Item;
+import com.clover.bookflow.global.converter.NationalLibraryXmlParser;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.text.StringEscapeUtils;
+import org.jsoup.Jsoup;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NationalLibraryApiService {
+
+  private final NationalLibraryApiClient nationalLibraryApiClient;
+
+  public List<BookAllSaveRequestDto> fetchRecommendedBooks() {
+    String books = nationalLibraryApiClient.fetchRecommendedBooks();
+    log.info("fetched recommended books : {}", books);
+    List<BookAllSaveRequestDto> bookAllList = new ArrayList<>();
+
+    try {
+      NatLibRecResponseDto response = NationalLibraryXmlParser.parse(books);
+      log.info("parsed books : {}", response.getTotalCount());
+
+      bookAllList = response.getList().stream()
+          .map(list -> {
+            Item item = list.getItem();
+            // HTML 디코딩 (Apache Commons Lang 사용)
+            String decodedMokcha = StringEscapeUtils.unescapeHtml4(item.getRecommokcha());
+            String decodedContents = StringEscapeUtils.unescapeHtml4(
+                item.getRecomcontens());
+            String plainMokcha = Jsoup.parse(decodedMokcha).text();
+            String plainContents = Jsoup.parse(decodedContents).text();
+
+            // 필요한 추가 가공 처리
+
+            return new BookAllSaveRequestDto(
+                item.getDrCode(),
+                item.getDrCodeName(),
+                item.getRecomtitle(),
+                item.getRecomauthor(),
+                item.getRecompublisher(),
+                item.getRecomisbn(),
+                item.getRecomfilepath(),
+                plainMokcha,
+                plainContents,
+                item.getPublishYear(),
+                item.getMokchFilePath()
+            );
+          })
+          .toList();
+
+      // saveDtoList를 DB 저장 등 다음 처리로 넘기기
+
+    } catch (Exception e) {
+      log.error("국립도서관 추천도서 파싱 중 오류", e);
+      // 예외 처리
+    }
+
+    return bookAllList;
+  }
+
+  /**
+   * 현재 API 응답 정보가 부족하여 사용 보류 중입니다.
+   * 추후 API 응답 개선 시 재사용 가능합니다.
+   */
+//  public List<BookDetailSaveRequestDto> fetchBookDetails(List<BookSaveRequestDto> books) {
+//    List<BookDetailSaveRequestDto> bookDetails = new ArrayList<>();
+//    for (BookSaveRequestDto book : books) {
+//      // 각 책에 대해 API 호출
+//      try {
+//        // 필요한 인자 넘기기 (isbn)
+//        log.info("상세 정보 API 호출 대상 : {}", book.isbn());
+//        String responseString = nationalLibraryApiClient.fetchBookDetailString(book.isbn());
+//        log.info(responseString);
+//        NationalLibraryResponseDto response = nationalLibraryApiClient.fetchBookDetail(book.isbn());
+//        Doc doc = response.docs().isEmpty() ? null : response.docs().getFirst();
+//        log.info("수신된 정보 : {}", doc != null ? doc.eaIsbn() : "응답 없음");
+//
+//        if (doc != null) {
+//          BookDetailSaveRequestDto dto = BookDetailSaveRequestDto.complete(
+//              doc.eaIsbn(),
+//              doc.ddc(),
+//              doc.kdc(),
+//              doc.bookTbCntUrl(),
+//              doc.bookTbCnt(),
+//              doc.bookIntroductionUrl(),
+//              doc.bookIntroduction(),
+//              doc.bookSummaryUrl(),
+//              doc.bookSummary(),
+//              doc.subject(),
+//              doc.page()
+//          );
+//          bookDetails.add(dto);
+//        } else {
+//          // isbn, 상태 저장
+//          bookDetails.add(BookDetailSaveRequestDto.noDetail(book.isbn()));
+//          log.warn("No detail found for ISBN: {}", book.isbn());
+//        }
+//      } catch (Exception e) {
+//        // isbn, 상태 저장
+//        bookDetails.add(BookDetailSaveRequestDto.error(book.isbn()));
+//        log.error("Failed to fetch details for book: {}", book.isbn(), e);
+//      }
+//    }
+//    return bookDetails;
+//  }
+
+}

--- a/src/main/java/com/clover/bookflow/domain/book/service/ScheduledBookIngestService.java
+++ b/src/main/java/com/clover/bookflow/domain/book/service/ScheduledBookIngestService.java
@@ -1,9 +1,11 @@
 package com.clover.bookflow.domain.book.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ScheduledBookIngestService {
@@ -13,8 +15,10 @@ public class ScheduledBookIngestService {
   // Todo: 편집자 추천 : 월 1 회
 
   // 베스트셀러
-  @Scheduled(cron = "0 0 2 ? * MON")
+//  @Scheduled(cron = "0 0 2 ? * MON")
+  @Scheduled(cron = "0 */1 * * * *") // 테스트용
   public void ingestWeeklyBestsellers() {
+    log.info("스케줄러 실행됨");
     adminBookIngestService.ingestBestSellers();
   }
 

--- a/src/main/java/com/clover/bookflow/domain/book/service/ScheduledBookIngestService.java
+++ b/src/main/java/com/clover/bookflow/domain/book/service/ScheduledBookIngestService.java
@@ -1,0 +1,24 @@
+package com.clover.bookflow.domain.book.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ScheduledBookIngestService {
+
+  private final AdminBookIngestService adminBookIngestService;
+
+  // Todo: 편집자 추천 : 월 1 회
+
+  // 베스트셀러
+  @Scheduled(cron = "0 0 2 ? * MON")
+  public void ingestWeeklyBestsellers() {
+    adminBookIngestService.ingestBestSellers();
+  }
+
+  // Todo: 주목 신간 : 매주 수 2시
+
+
+}

--- a/src/main/java/com/clover/bookflow/global/converter/NationalLibraryXmlParser.java
+++ b/src/main/java/com/clover/bookflow/global/converter/NationalLibraryXmlParser.java
@@ -1,0 +1,12 @@
+package com.clover.bookflow.global.converter;
+
+import com.clover.bookflow.domain.book.dto.NatLibRecResponseDto;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+
+public class NationalLibraryXmlParser {
+
+  public static NatLibRecResponseDto parse(String xml) throws Exception {
+    XmlMapper xmlMapper = new XmlMapper();
+    return xmlMapper.readValue(xml, NatLibRecResponseDto.class);
+  }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -37,6 +37,12 @@ jwt:
   access-token-expiration-ms: 3600000
   refresh-token-expiration-ms: 604800000
 
+aladin:
+  ttbkey: ${ALADIN_TTBKEY}
+
+nl:
+  key: ${NL_KEY}
+
 springdoc:
   swagger-ui:
     path: /swagger-ui.html  # Swagger UI 경로

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -31,3 +31,9 @@ jwt:
   secret: ${JWT_SECRET}
   access-token-expiration-ms: 1000
   refresh-token-expiration-ms: 5000
+
+aladin:
+  ttbkey: ${ALADIN_TTBKEY}
+
+nl:
+  key: ${NL_KEY}


### PR DESCRIPTION
# [#38] 관리자 도서 수집 기능 구현

---

## 📌 개요

알라딘/국립중앙도서관 API를 통해 도서 데이터를 수집하고 저장하는 기능을 관리자용으로 구현했습니다.  
해당 기능은 스케줄러와 수동 API 호출 두 가지 방식으로 실행되며, 중복 도서 필터링 및 도서 분류 로직도 포함되어 있습니다.

---

## ✨ 주요 변경 사항

- 도서 수집 전용 `AdminBookIngestService` 구현
  - 알라딘: 베스트셀러 조회 → 도서 저장
  - 국립중앙도서관: 추천 도서 조회 → 도서 저장
- 관리자용 도서 수집 트리거 API (`AdminBookController`) 추가
- 주기적 수집 기능 (`ScheduledBookIngestService`) 구현
- 스케줄링 활성화를 위한 `@EnableScheduling` 및 `SchedulingConfig` 추가
- 수집 대상 도서 분류용 DTO (`BookClassificationDto`) 구현
- 도서 저장용 서비스 (`BookService`)에 저장 로직 추가
- 외부 API 호출 결과를 변환하는 DTO 설계 및 활용
- 관련 의존성(jsoup, commons-text 등) 및 설정 추가

---

## ✅ 테스트

- [x] `/admin/books/ingest/bestsellers` → 알라딘 베스트셀러 수집 및 저장 정상 동작 확인
- [x] `/admin/books/ingest/recommended` → 국립도서관 추천도서 수집 및 저장 정상 동작 확인
- [x] 테스트용 cron(`0 */1 * * * *`) 설정으로 스케줄러 자동 실행 확인
- [x] 기존 도서 분류 로직 정상 동작 (이미 저장된 도서 필터링됨)

---

## 🔖 참고

- 알라딘 Open API
- 국립중앙도서관 추천도서 API
- 실제 배포용 스케줄러 cron: `0 0 2 ? * MON` (매주 월요일 02:00 실행)

---

## 🔗 관련 이슈

Closes #38 
