### PR TITLE
[Feature] 커스텀 PermissionEvaluator 및 도메인 기반 권한 체크 구조 도입

### DIFF
--- a/src/main/java/com/clover/bookflow/config/MethodSecurityConfig.java
+++ b/src/main/java/com/clover/bookflow/config/MethodSecurityConfig.java
@@ -1,0 +1,22 @@
+package com.clover.bookflow.config;
+
+import com.clover.bookflow.domain.auth.security.permission.CustomPermissionEvaluator;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.access.expression.method.DefaultMethodSecurityExpressionHandler;
+import org.springframework.security.access.expression.method.MethodSecurityExpressionHandler;
+
+@Configuration
+@RequiredArgsConstructor
+public class MethodSecurityConfig {
+
+  private final CustomPermissionEvaluator permissionEvaluator;
+
+  @Bean
+  public MethodSecurityExpressionHandler methodSecurityExpressionHandler() {
+    DefaultMethodSecurityExpressionHandler expressionHandler = new DefaultMethodSecurityExpressionHandler();
+    expressionHandler.setPermissionEvaluator(permissionEvaluator);
+    return expressionHandler;
+  }
+}

--- a/src/main/java/com/clover/bookflow/domain/auth/security/permission/CustomPermissionEvaluator.java
+++ b/src/main/java/com/clover/bookflow/domain/auth/security/permission/CustomPermissionEvaluator.java
@@ -1,0 +1,43 @@
+package com.clover.bookflow.domain.auth.security.permission;
+
+import java.io.Serializable;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.PermissionEvaluator;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CustomPermissionEvaluator implements PermissionEvaluator {
+
+  private final List<DomainPermissionEvaluator> evaluators;
+
+  @Override
+  public boolean hasPermission(Authentication authentication, Object targetDomainObject,
+      Object permission) {
+    return false;
+  }
+  // 객체 직접 넘겨줘야 해서 보통 두번째 메서드 사용
+
+
+  @Override
+  public boolean hasPermission(Authentication authentication, Serializable targetId,
+      String targetType, Object permission) {
+    if (authentication == null || permission == null || targetId == null || targetType == null) {
+      return false;
+    }
+
+    // 관리자 무조건 통과
+    if (authentication.getAuthorities().stream()
+        .anyMatch(auth -> auth.getAuthority().equals("ROLE_ADMIN"))) {
+      return true;
+    }
+
+    return evaluators.stream()
+        .filter(e -> e.supports(targetType))
+        .findFirst()
+        .map(e -> e.hasPermission(authentication, targetId, permission.toString()))
+        .orElse(false);
+  }
+}

--- a/src/main/java/com/clover/bookflow/domain/auth/security/permission/DomainPermissionEvaluator.java
+++ b/src/main/java/com/clover/bookflow/domain/auth/security/permission/DomainPermissionEvaluator.java
@@ -1,0 +1,11 @@
+package com.clover.bookflow.domain.auth.security.permission;
+
+import java.io.Serializable;
+import org.springframework.security.core.Authentication;
+
+public interface DomainPermissionEvaluator {
+
+  boolean supports(String targetType); // 지원하는 도메인인지 확인
+
+  boolean hasPermission(Authentication authentication, Serializable targetId, String permission);
+}

--- a/src/main/java/com/clover/bookflow/domain/common/AuthorIdentifiable.java
+++ b/src/main/java/com/clover/bookflow/domain/common/AuthorIdentifiable.java
@@ -1,0 +1,6 @@
+package com.clover.bookflow.domain.common;
+
+public interface AuthorIdentifiable {
+
+  Long getAuthorId();
+}


### PR DESCRIPTION
# [#45] 커스텀 PermissionEvaluator 및 도메인 기반 권한 체크 구조 도입

---

## 📌 개요

게시글(BlogPost) 및 향후 추가될 도메인 객체에 대해 작성자 및 관리자 권한을 일관되고 확장 가능하게 체크하기 위해,  
Spring Security의 `PermissionEvaluator`를 커스텀 구현하고, 도메인별 권한 평가기(`DomainPermissionEvaluator`) 인터페이스 및 구현체를 도입하였습니다.  
또한, 작성자 식별을 위한 `AuthorIdentifiable` 인터페이스를 정의하여 권한 검증 로직을 도메인 단위로 추상화하고 중복을 줄였습니다.

---

## ✨ 주요 변경 사항

- `AuthorIdentifiable` 인터페이스 추가 및 주요 도메인에 적용  
- `DomainPermissionEvaluator` 인터페이스 및 도메인별 구현체 작성  
- `CustomPermissionEvaluator` 구현 및 도메인별 권한 평가기 위임 로직 추가  
- Spring Security 설정에 커스텀 PermissionEvaluator 등록 (`MethodSecurityConfig`)  

---

## ✅ 테스트

---

## 🔖 참고

---

## 🔗 관련 이슈

Related #45 
