### PR TITLE
[Feature] @WithMockCustomUser 테스트 어노테이션 및 SecurityContextFactory 추가

### DIFF
--- a/src/main/java/com/clover/bookflow/domain/member/entity/Member.java
+++ b/src/main/java/com/clover/bookflow/domain/member/entity/Member.java
@@ -63,13 +63,14 @@ public class Member extends BaseTimeEntity {
   }
 
 
-  protected Member(UUID uuid, String email, String password, String nickname) {
+  protected Member(UUID uuid, String email, String password, String nickname, Role role,
+      MemberStatus memberStatus) {
     this.uuid = uuid;
     this.email = email;
     this.password = password;
     this.nickname = nickname;
-    this.role = Role.USER;
-    this.memberStatus = MemberStatus.ACTIVE;
+    this.role = role;
+    this.memberStatus = memberStatus;
   }
 
 

--- a/src/test/java/com/clover/bookflow/domain/auth/security/annotation/WithMockCustomUser.java
+++ b/src/test/java/com/clover/bookflow/domain/auth/security/annotation/WithMockCustomUser.java
@@ -1,0 +1,26 @@
+package com.clover.bookflow.domain.auth.security.annotation;
+
+import com.clover.bookflow.domain.auth.security.factory.WithMockCustomUserSecurityContextFactory;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithMockCustomUserSecurityContextFactory.class)
+public @interface WithMockCustomUser {
+
+  String uuid() default "00000000-0000-0000-0000-000000000000";
+
+  String email() default "test@bookflow.com";
+
+  String password() default "encoded-password"; // 암호화된 상태라고 가정
+
+  String nickname() default "테스트유저";
+
+  String role() default "USER";
+
+  String status() default "ACTIVE"; // MemberStatus
+
+  long id() default 1L;
+
+}

--- a/src/test/java/com/clover/bookflow/domain/auth/security/factory/WithMockCustomUserSecurityContextFactory.java
+++ b/src/test/java/com/clover/bookflow/domain/auth/security/factory/WithMockCustomUserSecurityContextFactory.java
@@ -1,0 +1,48 @@
+package com.clover.bookflow.domain.auth.security.factory;
+
+import com.clover.bookflow.domain.auth.security.CustomMemberDetails;
+import com.clover.bookflow.domain.auth.security.annotation.WithMockCustomUser;
+import com.clover.bookflow.domain.member.entity.Member;
+import com.clover.bookflow.domain.member.entity.MemberTestHelper;
+import com.clover.bookflow.domain.member.enums.MemberStatus;
+import com.clover.bookflow.domain.member.enums.Role;
+import java.util.UUID;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+public class WithMockCustomUserSecurityContextFactory implements
+    WithSecurityContextFactory<WithMockCustomUser> {
+
+  @Override
+  public SecurityContext createSecurityContext(WithMockCustomUser annotation) {
+    UUID uuid = UUID.fromString(annotation.uuid());
+    String email = annotation.email();
+    String password = annotation.password();
+    String nickname = annotation.nickname();
+    Role role = Role.valueOf(annotation.role());
+    MemberStatus status = MemberStatus.valueOf(annotation.status());
+
+    Member member = MemberTestHelper.createTestUser(
+        uuid,
+        email,
+        password,
+        nickname,
+        role,
+        status
+    );
+
+    CustomMemberDetails principal = new CustomMemberDetails(member);
+    UsernamePasswordAuthenticationToken auth =
+        UsernamePasswordAuthenticationToken.authenticated(
+            principal,
+            principal.getPassword(),
+            principal.getAuthorities()
+        );
+
+    SecurityContext context = SecurityContextHolder.createEmptyContext();
+    context.setAuthentication(auth);
+    return context;
+  }
+}

--- a/src/test/java/com/clover/bookflow/domain/member/entity/MemberTestHelper.java
+++ b/src/test/java/com/clover/bookflow/domain/member/entity/MemberTestHelper.java
@@ -1,5 +1,7 @@
 package com.clover.bookflow.domain.member.entity;
 
+import com.clover.bookflow.domain.member.enums.MemberStatus;
+import com.clover.bookflow.domain.member.enums.Role;
 import java.util.UUID;
 
 public class MemberTestHelper {
@@ -16,7 +18,12 @@ public class MemberTestHelper {
   public static Member createTestUser() {
     UUID testUuid = UUID.randomUUID();
     return new Member(testUuid, DEFAULT_EMAIL, DEFAULT_PASSWORD,
-        DEFAULT_NICKNAME);
+        DEFAULT_NICKNAME, Role.USER, MemberStatus.ACTIVE);
+  }
+
+  public static Member createTestUser(UUID uuid, String email, String password, String nickname,
+      Role role, MemberStatus status) {
+    return new Member(uuid, email, password, nickname, role, status);
   }
 
 


### PR DESCRIPTION
# [#47] @WithMockCustomUser 테스트 어노테이션 및 SecurityContextFactory 추가

---

## 📌 개요

프로젝트에서 인증 사용자 정보를 담는 `CustomUserDetails`(`CustomMemberDetails`)를 사용하고 있습니다.  
기본 Spring Security 테스트 어노테이션인 `@WithMockUser`는 단순히 username과 권한 정보만 모킹하기 때문에,  
복잡한 도메인 정보를 포함하는 `CustomUserDetails`를 대체하기 어렵고 현실적인 인증 컨텍스트를 재현할 수 없습니다.

따라서, 테스트 환경에서 `CustomUserDetails`를 기반으로 한 실제 도메인 사용자 정보를 반영할 수 있도록  
커스텀 테스트 어노테이션 `@WithMockCustomUser`와 이를 처리하는 `SecurityContextFactory`를 새로 도입하였습니다.

이를 통해 인증 및 권한 검증 로직을 도메인 모델과 동일한 환경에서 신뢰성 있게 테스트할 수 있습니다.

---

## ✨ 주요 변경 사항

- `@WithMockCustomUser` 어노테이션 추가  
  - UUID, 이메일, 패스워드, 닉네임, 역할(role), 상태(status), ID 등 실제 도메인 사용자 필드 반영 가능  
- `WithMockCustomUserSecurityContextFactory` 구현 
- Member 엔티티 및 테스트 헬퍼 업데이트

---

## ✅ 테스트
- Controller 테스트 작성과 함께 테스트 예정

---

## 🔖 참고

- 기본 `@WithMockUser`는 단순 인증 모킹에 적합하지만, `CustomUserDetails` 기반 복잡한 도메인 인증 시에는 한계가 있습니다.  
- `@WithMockCustomUser`와 `SecurityContextFactory`를 통해 실제 도메인 사용자 정보를 반영한 테스트 환경 구축이 가능합니다.

---

## 🔗 관련 이슈

Closes #47 
