### PR TITLE
[FEATURE] 블로그 게시글 CRUD 구현

### DIFF
--- a/src/main/java/com/clover/bookflow/config/MethodSecurityConfig.java
+++ b/src/main/java/com/clover/bookflow/config/MethodSecurityConfig.java
@@ -6,8 +6,10 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.access.expression.method.DefaultMethodSecurityExpressionHandler;
 import org.springframework.security.access.expression.method.MethodSecurityExpressionHandler;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 
 @Configuration
+@EnableMethodSecurity
 @RequiredArgsConstructor
 public class MethodSecurityConfig {
 

--- a/src/main/java/com/clover/bookflow/config/SecurityConfig.java
+++ b/src/main/java/com/clover/bookflow/config/SecurityConfig.java
@@ -7,7 +7,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
-import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -21,7 +20,6 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @Configuration
 @EnableWebSecurity
-@EnableMethodSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
 

--- a/src/main/java/com/clover/bookflow/domain/auth/security/permission/BlogPostPermissionEvaluator.java
+++ b/src/main/java/com/clover/bookflow/domain/auth/security/permission/BlogPostPermissionEvaluator.java
@@ -1,6 +1,5 @@
-package com.clover.bookflow.domain.blogpost.security;
+package com.clover.bookflow.domain.auth.security.permission;
 
-import com.clover.bookflow.domain.auth.security.permission.DomainPermissionEvaluator;
 import com.clover.bookflow.domain.blogpost.entity.BlogPost;
 import com.clover.bookflow.domain.blogpost.repository.BlogPostRepository;
 import com.clover.bookflow.domain.member.entity.Member;

--- a/src/main/java/com/clover/bookflow/domain/auth/security/permission/BlogPostPermissionEvaluator.java
+++ b/src/main/java/com/clover/bookflow/domain/auth/security/permission/BlogPostPermissionEvaluator.java
@@ -1,0 +1,47 @@
+package com.clover.bookflow.domain.blogpost.security;
+
+import com.clover.bookflow.domain.auth.security.permission.DomainPermissionEvaluator;
+import com.clover.bookflow.domain.blogpost.entity.BlogPost;
+import com.clover.bookflow.domain.blogpost.repository.BlogPostRepository;
+import com.clover.bookflow.domain.member.entity.Member;
+import java.io.Serializable;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class BlogPostPermissionEvaluator implements DomainPermissionEvaluator {
+
+  private final BlogPostRepository blogPostRepository;
+
+  @Override
+  public boolean supports(String targetType) {
+    return "BLOG_POST".equalsIgnoreCase(targetType);
+  }
+
+  @Override
+  public boolean hasPermission(Authentication authentication, Serializable targetId,
+      String permission) {
+    if (authentication == null || targetId == null || permission == null) {
+      return false;
+    }
+
+    Member currentUser = (Member) authentication.getPrincipal();
+
+    Optional<BlogPost> blogPostOpt = blogPostRepository.findById((Long) targetId);
+    if (blogPostOpt.isEmpty()) {
+      return false;
+    }
+
+    BlogPost blogPost = blogPostOpt.get();
+
+    return switch (permission.toUpperCase()) {
+      case "READ" -> blogPost.isAccessibleBy(currentUser);
+      case "WRITE" -> blogPost.getAuthor().equals(currentUser) || currentUser.isAdmin();
+      case "DELETE" -> blogPost.getAuthor().equals(currentUser) || currentUser.isAdmin();
+      default -> false;
+    };
+  }
+}

--- a/src/main/java/com/clover/bookflow/domain/blogpost/controller/BlogPostController.java
+++ b/src/main/java/com/clover/bookflow/domain/blogpost/controller/BlogPostController.java
@@ -1,0 +1,88 @@
+package com.clover.bookflow.domain.blogpost.controller;
+
+import com.clover.bookflow.domain.auth.security.CustomMemberDetails;
+import com.clover.bookflow.domain.blogpost.dto.request.BlogPostCreateRequest;
+import com.clover.bookflow.domain.blogpost.dto.request.BlogPostUpdateRequest;
+import com.clover.bookflow.domain.blogpost.dto.response.BlogPostResponse;
+import com.clover.bookflow.domain.blogpost.dto.response.BlogPostSimpleResponse;
+import com.clover.bookflow.domain.blogpost.service.BlogPostService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/blog-posts")
+@RequiredArgsConstructor
+public class BlogPostController {
+
+  private final BlogPostService blogPostService;
+
+  @PreAuthorize("hasAnyRole('USER', 'ADMIN')")
+  @PostMapping
+  public BlogPostResponse createBlogPost(
+      @Valid @RequestBody BlogPostCreateRequest request,
+      @AuthenticationPrincipal CustomMemberDetails userDetails) {
+    return blogPostService.createBlogPost(request, userDetails.getId());
+  }
+
+  @PreAuthorize("@blogPostPermissionEvaluator.hasPermission(authentication, #postId, 'READ')")
+  @GetMapping("/{postId}")
+  public BlogPostResponse getBlogPost(
+      @PathVariable Long postId,
+      @AuthenticationPrincipal CustomMemberDetails userDetails) {
+    return blogPostService.getBlogPost(postId, userDetails != null ? userDetails.getId() : null);
+  }
+
+  @GetMapping("/public")
+  public Page<BlogPostSimpleResponse> getPublicPosts(
+      @PageableDefault(size = 10, sort = "createdDate", direction = Sort.Direction.DESC) Pageable pageable) {
+    return blogPostService.getPublicBlogPosts(pageable);
+  }
+
+  @PreAuthorize("hasAnyRole('ADMIN', 'USER')") // 필요한 권한만 넣으세요
+  @GetMapping("/author/{authorId}")
+  public Page<BlogPostSimpleResponse> getPostsByAuthor(
+      @PathVariable Long authorId,
+      @PageableDefault(size = 10, sort = "createdDate", direction = Sort.Direction.DESC) Pageable pageable) {
+    return blogPostService.getPublicPostsByAuthor(authorId, pageable);
+  }
+
+  @PreAuthorize("isAuthenticated()")
+  @GetMapping("/me")
+  public Page<BlogPostSimpleResponse> getMyPosts(
+      @AuthenticationPrincipal CustomMemberDetails userDetails,
+      @PageableDefault(size = 10, sort = "createdDate", direction = Sort.Direction.DESC) Pageable pageable) {
+    return blogPostService.getMyBlogPosts(userDetails.getId(), pageable);
+  }
+
+  @PreAuthorize("@blogPostPermissionEvaluator.hasPermission(authentication, #postId, 'WRITE')")
+  @PutMapping("/{postId}")
+  public BlogPostResponse updateBlogPost(
+      @PathVariable Long postId,
+      @Valid @RequestBody BlogPostUpdateRequest request,
+      @AuthenticationPrincipal CustomMemberDetails userDetails) {
+    return blogPostService.updateBlogPost(postId, request, userDetails.getId());
+  }
+
+  @PreAuthorize("@blogPostPermissionEvaluator.hasPermission(authentication, #postId, 'DELETE')")
+  @DeleteMapping("/{postId}")
+  public void deleteBlogPost(
+      @PathVariable Long postId,
+      @AuthenticationPrincipal CustomMemberDetails userDetails) {
+    blogPostService.deleteBlogPost(postId, userDetails.getId());
+  }
+
+}

--- a/src/main/java/com/clover/bookflow/domain/blogpost/controller/BlogPostController.java
+++ b/src/main/java/com/clover/bookflow/domain/blogpost/controller/BlogPostController.java
@@ -6,12 +6,16 @@ import com.clover.bookflow.domain.blogpost.dto.request.BlogPostUpdateRequest;
 import com.clover.bookflow.domain.blogpost.dto.response.BlogPostResponse;
 import com.clover.bookflow.domain.blogpost.dto.response.BlogPostSimpleResponse;
 import com.clover.bookflow.domain.blogpost.service.BlogPostService;
+import com.clover.bookflow.global.response.ApiResponse;
+import com.clover.bookflow.global.response.PageResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -32,57 +36,87 @@ public class BlogPostController {
 
   @PreAuthorize("hasAnyRole('USER', 'ADMIN')")
   @PostMapping
-  public BlogPostResponse createBlogPost(
+  public ResponseEntity<ApiResponse<BlogPostResponse>> createBlogPost(
       @Valid @RequestBody BlogPostCreateRequest request,
       @AuthenticationPrincipal CustomMemberDetails userDetails) {
-    return blogPostService.createBlogPost(request, userDetails.getId());
+    System.out.println("Request: " + request);
+    System.out.println(
+        "User ID: " + (userDetails != null ? userDetails.getId() : "userDetails is null"));
+    System.out.println(
+        "User Role: " + userDetails.getAuthorities()
+    );
+
+    BlogPostResponse blogPostResponse = blogPostService.createBlogPost(request,
+        userDetails.getId());
+
+    return ResponseEntity
+        .status(HttpStatus.CREATED)
+        .body(ApiResponse.created(blogPostResponse));
   }
 
-  @PreAuthorize("@blogPostPermissionEvaluator.hasPermission(authentication, #postId, 'READ')")
+  @PreAuthorize("hasPermission(#postId, 'Blog_Post', 'READ')")
   @GetMapping("/{postId}")
-  public BlogPostResponse getBlogPost(
+  public ResponseEntity<ApiResponse<BlogPostResponse>> getBlogPost(
       @PathVariable Long postId,
       @AuthenticationPrincipal CustomMemberDetails userDetails) {
-    return blogPostService.getBlogPost(postId, userDetails != null ? userDetails.getId() : null);
+
+    BlogPostResponse response = blogPostService.getBlogPost(postId, userDetails.getId());
+    return ResponseEntity.ok(ApiResponse.success(response));
   }
 
   @GetMapping("/public")
-  public Page<BlogPostSimpleResponse> getPublicPosts(
+  public ResponseEntity<ApiResponse<PageResponse<BlogPostSimpleResponse>>> getPublicPosts(
       @PageableDefault(size = 10, sort = "createdDate", direction = Sort.Direction.DESC) Pageable pageable) {
-    return blogPostService.getPublicBlogPosts(pageable);
+
+    Page<BlogPostSimpleResponse> page = blogPostService.getPublicBlogPosts(pageable);
+    PageResponse<BlogPostSimpleResponse> pageResponse = PageResponse.from(page);
+    return ResponseEntity.ok(ApiResponse.success(pageResponse));
   }
 
-  @PreAuthorize("hasAnyRole('ADMIN', 'USER')") // 필요한 권한만 넣으세요
   @GetMapping("/author/{authorId}")
-  public Page<BlogPostSimpleResponse> getPostsByAuthor(
+  public ResponseEntity<ApiResponse<PageResponse<BlogPostSimpleResponse>>> getPostsByAuthor(
       @PathVariable Long authorId,
       @PageableDefault(size = 10, sort = "createdDate", direction = Sort.Direction.DESC) Pageable pageable) {
-    return blogPostService.getPublicPostsByAuthor(authorId, pageable);
+
+    Page<BlogPostSimpleResponse> page = blogPostService.getPublicPostsByAuthor(authorId, pageable);
+    PageResponse<BlogPostSimpleResponse> pageResponse = PageResponse.from(page);
+    return ResponseEntity.ok(ApiResponse.success(pageResponse));
   }
 
   @PreAuthorize("isAuthenticated()")
   @GetMapping("/me")
-  public Page<BlogPostSimpleResponse> getMyPosts(
+  public ResponseEntity<ApiResponse<PageResponse<BlogPostSimpleResponse>>> getMyPosts(
       @AuthenticationPrincipal CustomMemberDetails userDetails,
       @PageableDefault(size = 10, sort = "createdDate", direction = Sort.Direction.DESC) Pageable pageable) {
-    return blogPostService.getMyBlogPosts(userDetails.getId(), pageable);
+
+    Page<BlogPostSimpleResponse> page = blogPostService.getMyBlogPosts(userDetails.getId(),
+        pageable);
+    PageResponse<BlogPostSimpleResponse> pageResponse = PageResponse.from(page);
+    return ResponseEntity.ok(ApiResponse.success(pageResponse));
   }
 
-  @PreAuthorize("@blogPostPermissionEvaluator.hasPermission(authentication, #postId, 'WRITE')")
+  @PreAuthorize("hasPermission(#postId, 'Blog_Post', 'WRITE')")
   @PutMapping("/{postId}")
-  public BlogPostResponse updateBlogPost(
+  public ResponseEntity<ApiResponse<BlogPostResponse>> updateBlogPost(
       @PathVariable Long postId,
       @Valid @RequestBody BlogPostUpdateRequest request,
       @AuthenticationPrincipal CustomMemberDetails userDetails) {
-    return blogPostService.updateBlogPost(postId, request, userDetails.getId());
+
+    BlogPostResponse response = blogPostService.updateBlogPost(postId, request,
+        userDetails.getId());
+    System.out.println("blogPostResponse = " + response);
+    return ResponseEntity.ok(ApiResponse.success(response));
   }
 
-  @PreAuthorize("@blogPostPermissionEvaluator.hasPermission(authentication, #postId, 'DELETE')")
+  @PreAuthorize("hasPermission(#postId, 'Blog_Post', 'DELETE')")
   @DeleteMapping("/{postId}")
-  public void deleteBlogPost(
+  public ResponseEntity<ApiResponse<Void>> deleteBlogPost(
       @PathVariable Long postId,
       @AuthenticationPrincipal CustomMemberDetails userDetails) {
+
     blogPostService.deleteBlogPost(postId, userDetails.getId());
+    return ResponseEntity.noContent().build();
   }
+
 
 }

--- a/src/main/java/com/clover/bookflow/domain/blogpost/dto/request/BlogPostCreateRequest.java
+++ b/src/main/java/com/clover/bookflow/domain/blogpost/dto/request/BlogPostCreateRequest.java
@@ -1,10 +1,11 @@
 package com.clover.bookflow.domain.blogpost.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
 import java.util.List;
 
 public record BlogPostCreateRequest(
-    String title,
-    String content,
+    @NotBlank String title,
+    @NotBlank String content,
     List<Long> bookIds
 ) {
 

--- a/src/main/java/com/clover/bookflow/domain/blogpost/dto/request/BlogPostCreateRequest.java
+++ b/src/main/java/com/clover/bookflow/domain/blogpost/dto/request/BlogPostCreateRequest.java
@@ -1,0 +1,11 @@
+package com.clover.bookflow.domain.blogpost.dto.request;
+
+import java.util.List;
+
+public record BlogPostCreateRequest(
+    String title,
+    String content,
+    List<Long> bookIds
+) {
+
+}

--- a/src/main/java/com/clover/bookflow/domain/blogpost/dto/request/BlogPostUpdateRequest.java
+++ b/src/main/java/com/clover/bookflow/domain/blogpost/dto/request/BlogPostUpdateRequest.java
@@ -1,11 +1,12 @@
 package com.clover.bookflow.domain.blogpost.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
 import java.util.List;
 
 public record BlogPostUpdateRequest(
 
-    String title,
-    String content,
+    @NotBlank String title,
+    @NotBlank String content,
     List<Long> bookIds
 ) {
 

--- a/src/main/java/com/clover/bookflow/domain/blogpost/dto/request/BlogPostUpdateRequest.java
+++ b/src/main/java/com/clover/bookflow/domain/blogpost/dto/request/BlogPostUpdateRequest.java
@@ -1,0 +1,12 @@
+package com.clover.bookflow.domain.blogpost.dto.request;
+
+import java.util.List;
+
+public record BlogPostUpdateRequest(
+
+    String title,
+    String content,
+    List<Long> bookIds
+) {
+
+}

--- a/src/main/java/com/clover/bookflow/domain/blogpost/dto/response/BlogPostResponse.java
+++ b/src/main/java/com/clover/bookflow/domain/blogpost/dto/response/BlogPostResponse.java
@@ -1,0 +1,38 @@
+package com.clover.bookflow.domain.blogpost.dto.response;
+
+import com.clover.bookflow.domain.blogpost.entity.BlogPost;
+import com.clover.bookflow.domain.book.dto.BookInfoResponse;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public record BlogPostResponse(
+
+    Long id,
+    String title,
+    String content,
+    String authorName,
+    LocalDateTime createdAt,
+    LocalDateTime updatedAt,
+    List<BookInfoResponse> books
+) {
+
+  public static BlogPostResponse from(BlogPost blogPost) {
+    List<BookInfoResponse> bookResponses = blogPost.getBlogPostBooks().stream()
+        .map(bpBook -> {
+          var book = bpBook.getBook();
+          return new BookInfoResponse(book.getId(), book.getTitle(), book.getAuthor());
+        })
+        .collect(Collectors.toList());
+
+    return new BlogPostResponse(
+        blogPost.getId(),
+        blogPost.getTitle(),
+        blogPost.getContent(),
+        blogPost.getAuthor().getNickname(),
+        blogPost.getCreatedAt(),
+        blogPost.getUpdatedAt(),
+        bookResponses
+    );
+  }
+}

--- a/src/main/java/com/clover/bookflow/domain/blogpost/dto/response/BlogPostSimpleResponse.java
+++ b/src/main/java/com/clover/bookflow/domain/blogpost/dto/response/BlogPostSimpleResponse.java
@@ -1,0 +1,28 @@
+package com.clover.bookflow.domain.blogpost.dto.response;
+
+import com.clover.bookflow.domain.blogpost.entity.BlogPost;
+import java.time.LocalDateTime;
+
+public record BlogPostSimpleResponse(
+    Long id,
+    String title,
+    String summary,
+    String authorName,
+    LocalDateTime createdAt
+) {
+
+  public static BlogPostSimpleResponse from(BlogPost blogPost) {
+    // summary는 content 일부를 잘라서 만듦 (100자 제한)
+    String summary = blogPost.getContent().length() > 100
+        ? blogPost.getContent().substring(0, 100) + "..."
+        : blogPost.getContent();
+
+    return new BlogPostSimpleResponse(
+        blogPost.getId(),
+        blogPost.getTitle(),
+        summary,
+        blogPost.getAuthor().getNickname(),
+        blogPost.getCreatedAt()
+    );
+  }
+}

--- a/src/main/java/com/clover/bookflow/domain/blogpost/entity/BlogPost.java
+++ b/src/main/java/com/clover/bookflow/domain/blogpost/entity/BlogPost.java
@@ -1,0 +1,171 @@
+package com.clover.bookflow.domain.blogpost.entity;
+
+import com.clover.bookflow.domain.blogpost.enums.BlogPostState;
+import com.clover.bookflow.domain.book.entity.Book;
+import com.clover.bookflow.domain.member.entity.Member;
+import com.clover.bookflow.global.common.BaseTimeEntity;
+import com.clover.bookflow.global.errorcode.BlogPostErrorCode;
+import com.clover.bookflow.global.exception.BusinessException;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "blog_posts")
+public class BlogPost extends BaseTimeEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false, length = 255)
+  private String title;
+
+  @Lob
+  @Column(nullable = false)
+  private String content; // Markdown or HTML 형식 저장
+
+  @Column(nullable = false)
+  private BlogPostState state = BlogPostState.DRAFT;
+
+  // 여러 BlogPost는 한 명의 Member(작성자)에 속함
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name = "author_id", nullable = false)
+  private Member author;
+
+  // 하나의 BlogPost는 여러 BlogPostBook(도서 연결)을 가질 수 있음
+  @OneToMany(mappedBy = "blogPost", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<BlogPostBook> blogPostBooks = new ArrayList<>();
+
+  // 생성자
+  private BlogPost(String title, String content, Member author, BlogPostState state) {
+    this.title = title;
+    this.content = content;
+    this.author = author;
+    this.state = state;
+  }
+
+  public static BlogPost createDraft(String title, String content, Member author) {
+    return new BlogPost(title, content, author, BlogPostState.DRAFT);
+  }
+
+  public static BlogPost createPublished(String title, String content, Member author) {
+    return new BlogPost(title, content, author, BlogPostState.ACTIVE);
+  }
+
+  public void update(String newTitle, String newContent) {
+    if (this.state == BlogPostState.DELETED) {
+      throw new IllegalStateException("삭제된 글은 수정할 수 없습니다.");
+    }
+    this.title = newTitle;
+    this.content = newContent;
+    // 필요하면 수정 시간 갱신 등 추가
+  }
+
+  public void makePrivate() {
+    changeState(BlogPostState.PRIVATE);
+  }
+
+  public void publish() {
+    changeState(BlogPostState.ACTIVE);
+  }
+
+  public void delete() {
+    changeState(BlogPostState.DELETED);
+  }
+
+  public void saveAsDraft() {
+    changeState(BlogPostState.DRAFT);
+  }
+
+  private void changeState(BlogPostState newState) {
+    if (!canTransitionTo(newState)) {
+      throw new IllegalStateException("상태 전환 불가: " + this.state + " → " + newState);
+    }
+    this.state = newState;
+  }
+
+  private boolean canTransitionTo(BlogPostState newState) {
+    return switch (this.state) {
+      case DRAFT -> newState == BlogPostState.ACTIVE || newState == BlogPostState.PRIVATE
+          || newState == BlogPostState.DELETED;
+      case ACTIVE -> newState == BlogPostState.PRIVATE || newState == BlogPostState.DELETED;
+      case PRIVATE -> newState == BlogPostState.ACTIVE || newState == BlogPostState.DELETED;
+      case DELETED -> false;
+    };
+  }
+
+  public void addBook(Book book) {
+    BlogPostBook blogPostBook = new BlogPostBook(this, book);
+    this.blogPostBooks.add(blogPostBook);
+  }
+
+  public void addBooks(List<Book> books) {
+    if (books == null || books.isEmpty()) {
+      return;
+    }
+
+    for (Book book : books) {
+      addBook(book);
+    }
+  }
+
+  public void removeBook(Book book) {
+    blogPostBooks.removeIf(bpb -> bpb.getBook().equals(book));
+  }
+
+  // 상태 관련
+  public boolean isDeleted() {
+    return this.state == BlogPostState.DELETED;
+  }
+
+  public boolean isPrivate() {
+    return this.state == BlogPostState.PRIVATE;
+  }
+
+  public boolean isDraft() {
+    return this.state == BlogPostState.DRAFT;
+  }
+
+  public boolean isActive() {
+    return this.state == BlogPostState.ACTIVE;
+  }
+
+  public boolean isAccessibleBy(Member viewer) {
+    if (this.isDeleted()) {
+      return false;
+    }
+
+    boolean isOwner = this.author.equals(viewer);
+    boolean isAdmin = viewer != null && viewer.isAdmin();
+
+    if (this.isPrivate() || this.isDraft()) {
+      return isOwner || isAdmin;
+    }
+
+    return true;
+  }
+
+  public void validateAccessibleBy(Member viewer) {
+    if (!isAccessibleBy(viewer)) {
+      throw new BusinessException(BlogPostErrorCode.UNAUTHORIZED_ACCESS);
+    }
+  }
+
+}

--- a/src/main/java/com/clover/bookflow/domain/blogpost/entity/BlogPost.java
+++ b/src/main/java/com/clover/bookflow/domain/blogpost/entity/BlogPost.java
@@ -2,6 +2,7 @@ package com.clover.bookflow.domain.blogpost.entity;
 
 import com.clover.bookflow.domain.blogpost.enums.BlogPostState;
 import com.clover.bookflow.domain.book.entity.Book;
+import com.clover.bookflow.domain.common.AuthorIdentifiable;
 import com.clover.bookflow.domain.member.entity.Member;
 import com.clover.bookflow.global.common.BaseTimeEntity;
 import com.clover.bookflow.global.errorcode.BlogPostErrorCode;
@@ -28,7 +29,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "blog_posts")
-public class BlogPost extends BaseTimeEntity {
+public class BlogPost extends BaseTimeEntity implements AuthorIdentifiable {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -112,6 +113,13 @@ public class BlogPost extends BaseTimeEntity {
   }
 
   public void addBook(Book book) {
+    boolean alreadyLinked = blogPostBooks.stream()
+        .anyMatch(bpb -> bpb.getBook().equals(book));
+
+    if (alreadyLinked) {
+      return;
+    }
+
     BlogPostBook blogPostBook = new BlogPostBook(this, book);
     this.blogPostBooks.add(blogPostBook);
   }
@@ -120,7 +128,6 @@ public class BlogPost extends BaseTimeEntity {
     if (books == null || books.isEmpty()) {
       return;
     }
-
     for (Book book : books) {
       addBook(book);
     }
@@ -168,4 +175,8 @@ public class BlogPost extends BaseTimeEntity {
     }
   }
 
+  @Override
+  public Long getAuthorId() {
+    return author != null ? author.getId() : null;
+  }
 }

--- a/src/main/java/com/clover/bookflow/domain/blogpost/entity/BlogPostBook.java
+++ b/src/main/java/com/clover/bookflow/domain/blogpost/entity/BlogPostBook.java
@@ -1,0 +1,39 @@
+package com.clover.bookflow.domain.blogpost.entity;
+
+import com.clover.bookflow.domain.book.entity.Book;
+import com.clover.bookflow.global.common.BaseTimeEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "blogpost_books")
+public class BlogPostBook extends BaseTimeEntity { // 블로그 글과 도서 연결, 중간 엔티티
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "blog_post_id", nullable = false)
+  private BlogPost blogPost;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "book_id", nullable = false)
+  private Book book;
+
+  public BlogPostBook(BlogPost blogPost, Book book) {
+    this.blogPost = blogPost;
+    this.book = book;
+  }
+}

--- a/src/main/java/com/clover/bookflow/domain/blogpost/enums/BlogPostState.java
+++ b/src/main/java/com/clover/bookflow/domain/blogpost/enums/BlogPostState.java
@@ -1,0 +1,9 @@
+package com.clover.bookflow.domain.blogpost.enums;
+
+public enum BlogPostState {
+  
+  ACTIVE,    // 정상 게시글
+  DELETED,   // 논리 삭제된 글
+  PRIVATE,   // 비공개 글
+  DRAFT      // 임시 저장 등
+}

--- a/src/main/java/com/clover/bookflow/domain/blogpost/repository/BlogPostRepository.java
+++ b/src/main/java/com/clover/bookflow/domain/blogpost/repository/BlogPostRepository.java
@@ -1,0 +1,27 @@
+package com.clover.bookflow.domain.blogpost.repository;
+
+import com.clover.bookflow.domain.blogpost.entity.BlogPost;
+import com.clover.bookflow.domain.blogpost.enums.BlogPostState;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository // JPA 면 안붙여도 인식함
+public interface BlogPostRepository extends JpaRepository<BlogPost, Long> {
+
+  // 상태가 "DELETE" 가 아닌 글만 조회
+  Optional<BlogPost> findByIdAndStateNot(Long id, BlogPostState state);
+
+  // 전체 글 목록에서 "ACTIVE" 상태만 조회 (예: ACTIVE)
+  Page<BlogPost> findByState(BlogPostState state, Pageable pageable);
+
+  // 특정 작성자의 글 중 상태가 "ACTIVE" 인 글 조회
+  Page<BlogPost> findByAuthorIdAndState(Long authorId, BlogPostState state, Pageable pageable);
+
+  // 나의 글 중 상태가 "DELETED"가 아닌 글 조회
+  Page<BlogPost> findByAuthorIdAndStateNot(Long authorId, BlogPostState state, Pageable pageable);
+
+}
+

--- a/src/main/java/com/clover/bookflow/domain/blogpost/service/BlogPostService.java
+++ b/src/main/java/com/clover/bookflow/domain/blogpost/service/BlogPostService.java
@@ -1,0 +1,157 @@
+package com.clover.bookflow.domain.blogpost.service;
+
+import com.clover.bookflow.domain.blogpost.dto.request.BlogPostCreateRequest;
+import com.clover.bookflow.domain.blogpost.dto.request.BlogPostUpdateRequest;
+import com.clover.bookflow.domain.blogpost.dto.response.BlogPostResponse;
+import com.clover.bookflow.domain.blogpost.dto.response.BlogPostSimpleResponse;
+import com.clover.bookflow.domain.blogpost.entity.BlogPost;
+import com.clover.bookflow.domain.blogpost.enums.BlogPostState;
+import com.clover.bookflow.domain.blogpost.repository.BlogPostRepository;
+import com.clover.bookflow.domain.book.entity.Book;
+import com.clover.bookflow.domain.book.repository.BookRepository;
+import com.clover.bookflow.domain.member.entity.Member;
+import com.clover.bookflow.domain.member.repository.MemberRepository;
+import com.clover.bookflow.global.errorcode.BlogPostErrorCode;
+import com.clover.bookflow.global.errorcode.BookErrorCode;
+import com.clover.bookflow.global.errorcode.MemberErrorCode;
+import com.clover.bookflow.global.exception.BusinessException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class BlogPostService {
+
+  private final BlogPostRepository blogPostRepository;
+  private final MemberRepository memberRepository;
+  private final BookRepository bookRepository;
+
+  // 블로그 글 작성
+  @Transactional
+  public BlogPostResponse createBlogPost(BlogPostCreateRequest dto, Long memberId) {
+    Member author = findMemberById(memberId);
+
+    // 블로그 글 생성
+    BlogPost blogPost = BlogPost.createDraft(dto.title(), dto.content(), author);
+
+    // 책 목록 확인
+    List<Book> books = bookRepository.findAllById(dto.bookIds());
+    if (books.size() != dto.bookIds().size()) {
+      throw new BusinessException(BookErrorCode.BOOK_NOT_FOUND);
+    }
+
+    blogPost.addBooks(books);
+    blogPostRepository.save(blogPost);
+
+    return BlogPostResponse.from(blogPost);
+  }
+
+  // 블로그 글 단건 조회
+  public BlogPostResponse getBlogPost(Long postId, Long memberId) {
+    // DB에서 status가 DELETED인 글 제외
+    BlogPost blogPost = findBlogPostByIdAndStateNotDeleted(postId);
+
+    // 권한 체크
+    if (!canViewBlogPost(blogPost, memberId)) {
+      throw new BusinessException(BlogPostErrorCode.UNAUTHORIZED_ACCESS);
+    }
+
+    return BlogPostResponse.from(blogPost);
+  }
+
+  // 블로그 글 수정
+  @Transactional
+  public BlogPostResponse updateBlogPost(Long postId, BlogPostUpdateRequest dto, Long memberId) {
+    BlogPost blogPost = findBlogPostByIdAndStateNotDeleted(postId);
+
+    // 권한 체크
+    hasPermission(blogPost, memberId);
+
+    // 블로그 글 업데이트
+    blogPost.update(dto.title(), dto.content());
+
+    return BlogPostResponse.from(blogPost);
+  }
+
+  // 블로그 글 삭제
+  @Transactional
+  public void deleteBlogPost(Long postId, Long memberId) {
+    BlogPost blogPost = findBlogPostByIdAndStateNotDeleted(postId);
+
+    // 권한 체크
+    if (!hasPermission(blogPost, memberId)) {
+      throw new BusinessException(BlogPostErrorCode.UNAUTHORIZED_ACCESS);
+    }
+
+    // 글 삭제 처리
+    blogPost.delete();
+  }
+
+  // 활성화된 글과 비활성화된 글을 구분하는 메서드
+  private boolean canViewBlogPost(BlogPost blogPost, Long memberId) {
+    if (blogPost.isActive()) {
+      return true; // 활성화된 글은 누구나 볼 수 있음
+    }
+    return hasPermission(blogPost, memberId); // 비활성화된 글은 작성자나 관리자만 볼 수 있음
+  }
+
+  // 권한 확인 메서드
+  private boolean hasPermission(BlogPost blogPost, Long memberId) {
+    if (isAuthor(blogPost, memberId) || isMemberAdmin(memberId)) {
+      return true;
+    }
+    throw new BusinessException(BlogPostErrorCode.UNAUTHORIZED_ACCESS);
+  }
+
+  // 블로그 글 작성자 확인
+  private boolean isAuthor(BlogPost blogPost, Long memberId) {
+    return blogPost.getAuthor().getId().equals(memberId);
+  }
+
+  // 관리자인지 확인
+  private boolean isMemberAdmin(Long memberId) {
+    return memberRepository.findById(memberId)
+        .map(Member::isAdmin)
+        .orElse(false);
+  }
+
+  // BlogPost 객체 찾기
+  private BlogPost findBlogPostByIdAndStateNotDeleted(Long id) {
+    // 삭제된 것은 조회 안됨.
+    return blogPostRepository.findByIdAndStateNot(id, BlogPostState.DELETED)
+        .orElseThrow(() -> new BusinessException(BlogPostErrorCode.BLOG_POST_NOT_FOUND));
+  }
+
+  // Member 객체 찾기
+  private Member findMemberById(Long memberId) {
+    return memberRepository.findById(memberId)
+        .orElseThrow(() -> new BusinessException(MemberErrorCode.MEMBER_NOT_FOUND));
+  }
+
+  // 블로그 글 목록 조회 (전체)
+  public Page<BlogPostSimpleResponse> getPublicBlogPosts(Pageable pageable) {
+    Page<BlogPost> posts = blogPostRepository.findByState(BlogPostState.ACTIVE,
+        pageable);
+    return posts.map(BlogPostSimpleResponse::from);
+  }
+
+  // 작성자 페이지에서의 글 목록 조회
+  public Page<BlogPostSimpleResponse> getPublicPostsByAuthor(Long authorId, Pageable pageable) {
+    Page<BlogPost> posts = blogPostRepository.findByAuthorIdAndState(authorId,
+        BlogPostState.ACTIVE, pageable);
+    return posts.map(BlogPostSimpleResponse::from);
+  }
+
+  // 내 페이지에서의 글 목록 조회
+  public Page<BlogPostSimpleResponse> getMyBlogPosts(Long memberId, Pageable pageable) {
+    Page<BlogPost> posts = blogPostRepository.findByAuthorIdAndStateNot(memberId,
+        BlogPostState.DELETED, pageable);
+    return posts.map(BlogPostSimpleResponse::from);
+  }
+}

--- a/src/main/java/com/clover/bookflow/domain/blogpost/service/BlogPostService.java
+++ b/src/main/java/com/clover/bookflow/domain/blogpost/service/BlogPostService.java
@@ -71,7 +71,9 @@ public class BlogPostService {
     BlogPost blogPost = findBlogPostByIdAndStateNotDeleted(postId);
 
     // 권한 체크
-    hasPermission(blogPost, memberId);
+    if (!hasPermission(blogPost, memberId)) {
+      throw new BusinessException(BlogPostErrorCode.UNAUTHORIZED_ACCESS);
+    }
 
     // 블로그 글 업데이트
     blogPost.update(dto.title(), dto.content());
@@ -94,7 +96,7 @@ public class BlogPostService {
   }
 
   // 활성화된 글과 비활성화된 글을 구분하는 메서드
-  private boolean canViewBlogPost(BlogPost blogPost, Long memberId) {
+  boolean canViewBlogPost(BlogPost blogPost, Long memberId) {
     if (blogPost.isActive()) {
       return true; // 활성화된 글은 누구나 볼 수 있음
     }
@@ -102,11 +104,8 @@ public class BlogPostService {
   }
 
   // 권한 확인 메서드
-  private boolean hasPermission(BlogPost blogPost, Long memberId) {
-    if (isAuthor(blogPost, memberId) || isMemberAdmin(memberId)) {
-      return true;
-    }
-    throw new BusinessException(BlogPostErrorCode.UNAUTHORIZED_ACCESS);
+  boolean hasPermission(BlogPost blogPost, Long memberId) {
+    return isAuthor(blogPost, memberId) || isMemberAdmin(memberId);
   }
 
   // 블로그 글 작성자 확인

--- a/src/main/java/com/clover/bookflow/domain/book/dto/BookInfoResponse.java
+++ b/src/main/java/com/clover/bookflow/domain/book/dto/BookInfoResponse.java
@@ -1,0 +1,9 @@
+package com.clover.bookflow.domain.book.dto;
+
+public record BookInfoResponse(
+    Long id,
+    String title,
+    String author
+) {
+
+}

--- a/src/main/java/com/clover/bookflow/domain/member/entity/Member.java
+++ b/src/main/java/com/clover/bookflow/domain/member/entity/Member.java
@@ -81,4 +81,7 @@ public class Member extends BaseTimeEntity {
     this.memberStatus = MemberStatus.DELETED;
   }
 
+  public boolean isAdmin() {
+    return this.role == Role.ADMIN;
+  }
 }

--- a/src/main/java/com/clover/bookflow/domain/member/entity/Member.java
+++ b/src/main/java/com/clover/bookflow/domain/member/entity/Member.java
@@ -73,6 +73,17 @@ public class Member extends BaseTimeEntity {
     this.memberStatus = memberStatus;
   }
 
+  Member(Long id, UUID uuid, String email, String password, String nickname, Role role,
+      MemberStatus memberStatus) {
+    this.id = id;
+    this.uuid = uuid;
+    this.email = email;
+    this.password = password;
+    this.nickname = nickname;
+    this.role = role;
+    this.memberStatus = memberStatus;
+  }
+
 
   public static Member create(String email, String password, String nickname) {
     return new Member(email, password, nickname);

--- a/src/main/java/com/clover/bookflow/domain/member/entity/Member.java
+++ b/src/main/java/com/clover/bookflow/domain/member/entity/Member.java
@@ -63,12 +63,12 @@ public class Member extends BaseTimeEntity {
   }
 
 
-  protected Member(UUID uuid, String email, String password, String nickname) {
+  protected Member(UUID uuid, String email, String password, String nickname, Role role) {
     this.uuid = uuid;
     this.email = email;
     this.password = password;
     this.nickname = nickname;
-    this.role = Role.USER;
+    this.role = role;
     this.memberStatus = MemberStatus.ACTIVE;
   }
 

--- a/src/main/java/com/clover/bookflow/domain/readbook/entity/ReadBook.java
+++ b/src/main/java/com/clover/bookflow/domain/readbook/entity/ReadBook.java
@@ -1,0 +1,41 @@
+package com.clover.bookflow.domain.readbook.entity;
+
+import com.clover.bookflow.domain.book.entity.Book;
+import com.clover.bookflow.domain.member.entity.Member;
+import com.clover.bookflow.global.common.BaseTimeEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "read_books")
+public class ReadBook extends BaseTimeEntity { // 사용자가 읽은 도서 목록 관리, 중간 엔티티
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name = "member_id")
+  private Member member;
+
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name = "book_id")
+  private Book book;
+
+  public ReadBook(Member member, Book book) {
+    this.member = member;
+    this.book = book;
+  }
+
+}

--- a/src/main/java/com/clover/bookflow/global/common/BaseTimeEntity.java
+++ b/src/main/java/com/clover/bookflow/global/common/BaseTimeEntity.java
@@ -16,10 +16,10 @@ public abstract class BaseTimeEntity {
 
   @CreatedDate
   @Column(name = "created_at", nullable = false, updatable = false)
-  private LocalDateTime created;
+  private LocalDateTime createdAt;
 
   @LastModifiedDate
   @Column(name = "updated_at")
-  private LocalDateTime updatedDate;
+  private LocalDateTime updatedAt;
 
 }

--- a/src/main/java/com/clover/bookflow/global/errorcode/BlogPostErrorCode.java
+++ b/src/main/java/com/clover/bookflow/global/errorcode/BlogPostErrorCode.java
@@ -1,0 +1,24 @@
+package com.clover.bookflow.global.errorcode;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum BlogPostErrorCode implements ErrorCode {
+
+  BLOG_POST_NOT_FOUND("BLOGPOST_001", "해당 블로그 글이 존재하지 않습니다.", HttpStatus.NOT_FOUND),
+  UNAUTHORIZED_ACCESS("BLOGPOST_002", "블로그 글에 대한 권한이 없습니다.", HttpStatus.FORBIDDEN),
+  INVALID_BLOG_POST_STATE("BLOGPOST_003", "블로그 글의 상태가 유효하지 않습니다.", HttpStatus.BAD_REQUEST),
+  DELETED_BLOG_POST_ACCESS("BLOGPOST_005", "삭제된 블로그 글에는 접근할 수 없습니다.", HttpStatus.GONE),
+  DUPLICATE_TITLE("BLOGPOST_004", "이미 존재하는 블로그 글 제목입니다.", HttpStatus.CONFLICT);
+
+  private final String code;
+  private final String message;
+  private final HttpStatus status;
+
+  BlogPostErrorCode(String code, String message, HttpStatus status) {
+    this.code = code;
+    this.message = message;
+    this.status = status;
+  }
+}

--- a/src/main/java/com/clover/bookflow/global/errorcode/BookErrorCode.java
+++ b/src/main/java/com/clover/bookflow/global/errorcode/BookErrorCode.java
@@ -1,0 +1,24 @@
+package com.clover.bookflow.global.errorcode;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum BookErrorCode implements ErrorCode {
+
+  BOOK_NOT_FOUND("BOOK_001", "존재하지 않는 도서입니다.", HttpStatus.NOT_FOUND),
+  DUPLICATE_BOOK("BOOK_002", "이미 존재하는 도서입니다.", HttpStatus.CONFLICT),
+  INVALID_BOOK_DATA("BOOK_003", "도서 데이터가 유효하지 않습니다.", HttpStatus.BAD_REQUEST),
+  UNAUTHORIZED_ACCESS("BOOK_004", "도서에 대한 권한이 없습니다.", HttpStatus.FORBIDDEN);
+
+  private final String code;
+  private final String message;
+  private final HttpStatus status;
+
+  BookErrorCode(String code, String message, HttpStatus httpStatus) {
+    this.code = code;
+    this.message = message;
+    this.status = httpStatus;
+  }
+
+}

--- a/src/main/java/com/clover/bookflow/global/response/PageResponse.java
+++ b/src/main/java/com/clover/bookflow/global/response/PageResponse.java
@@ -1,0 +1,23 @@
+package com.clover.bookflow.global.response;
+
+import java.util.List;
+
+public record PageResponse<T>(
+    List<T> content,
+    Pagination pagination
+) {
+
+  public static <T> PageResponse<T> from(org.springframework.data.domain.Page<T> page) {
+    return new PageResponse<>(
+        page.getContent(),
+        new Pagination(
+            page.getNumber(),
+            page.getSize(),
+            page.getTotalPages(),
+            page.getTotalElements(),
+            page.isFirst(),
+            page.isLast()
+        )
+    );
+  }
+}

--- a/src/main/java/com/clover/bookflow/global/response/Pagination.java
+++ b/src/main/java/com/clover/bookflow/global/response/Pagination.java
@@ -1,0 +1,12 @@
+package com.clover.bookflow.global.response;
+
+public record Pagination(
+    int page,
+    int size,
+    int totalPages,
+    long totalElements,
+    boolean first,
+    boolean last
+) {
+
+}

--- a/src/test/java/com/clover/bookflow/common/TestHelper.java
+++ b/src/test/java/com/clover/bookflow/common/TestHelper.java
@@ -1,10 +1,12 @@
 package com.clover.bookflow.common;
 
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.Cookie;
+import java.util.Map;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
@@ -20,9 +22,30 @@ public class TestHelper {
     this.objectMapper = objectMapper;
   }
 
+  public ResultActions getRequest(String url) throws Exception {
+    return performRequest(get(url));
+  }
+
+  public ResultActions getRequest(String url, Map<String, String> params) throws Exception {
+    MockHttpServletRequestBuilder builder = get(url);
+    if (params != null) {
+      params.forEach(builder::param);
+    }
+    return mockMvc.perform(builder);
+  }
+
+
   // post 요청
   public ResultActions postRequest(String url, Object request) throws Exception {
     return performRequest(post(url), request);
+  }
+
+  private ResultActions performRequest(MockHttpServletRequestBuilder builder) throws Exception {
+    return mockMvc.perform(
+        builder
+            .contentType(MediaType.APPLICATION_JSON)
+            .with(csrf())
+    );
   }
 
 

--- a/src/test/java/com/clover/bookflow/domain/auth/security/factory/WithMockCustomUserSecurityContextFactory.java
+++ b/src/test/java/com/clover/bookflow/domain/auth/security/factory/WithMockCustomUserSecurityContextFactory.java
@@ -17,6 +17,7 @@ public class WithMockCustomUserSecurityContextFactory implements
 
   @Override
   public SecurityContext createSecurityContext(WithMockCustomUser annotation) {
+    Long id = annotation.id();
     UUID uuid = UUID.fromString(annotation.uuid());
     String email = annotation.email();
     String password = annotation.password();
@@ -24,7 +25,8 @@ public class WithMockCustomUserSecurityContextFactory implements
     Role role = Role.valueOf(annotation.role());
     MemberStatus status = MemberStatus.valueOf(annotation.status());
 
-    Member member = MemberTestHelper.createTestUser(
+    Member member = MemberTestHelper.createTestMemberWithId(
+        id,
         uuid,
         email,
         password,

--- a/src/test/java/com/clover/bookflow/domain/blogpost/controller/BlogPostControllerTest.java
+++ b/src/test/java/com/clover/bookflow/domain/blogpost/controller/BlogPostControllerTest.java
@@ -1,0 +1,376 @@
+package com.clover.bookflow.domain.blogpost.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.eq;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.clover.bookflow.common.TestHelper;
+import com.clover.bookflow.config.SecurityConfig;
+import com.clover.bookflow.domain.auth.security.JwtAuthenticationFilter;
+import com.clover.bookflow.domain.auth.security.annotation.WithMockCustomUser;
+import com.clover.bookflow.domain.blogpost.dto.request.BlogPostCreateRequest;
+import com.clover.bookflow.domain.blogpost.dto.request.BlogPostUpdateRequest;
+import com.clover.bookflow.domain.blogpost.dto.response.BlogPostResponse;
+import com.clover.bookflow.domain.blogpost.dto.response.BlogPostSimpleResponse;
+import com.clover.bookflow.domain.blogpost.service.BlogPostService;
+import com.clover.bookflow.domain.book.dto.BookInfoResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+@WebMvcTest(BlogPostController.class)
+@Import(SecurityConfig.class)
+@ExtendWith({RestDocumentationExtension.class, SpringExtension.class})
+class BlogPostControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+  @Autowired
+  private ObjectMapper objectMapper;
+  @MockitoBean
+  private BlogPostService blogPostService;
+  @MockitoBean
+  private JwtAuthenticationFilter jwtAuthenticationFilter;
+  @Autowired
+  private WebApplicationContext context;
+
+  private static final String BASE_URL = "/api/v1/blog-posts";
+  private TestHelper testHelper;
+
+  @BeforeEach
+  void setUp(RestDocumentationContextProvider provider) {
+    this.mockMvc =
+        MockMvcBuilders.webAppContextSetup(context)
+            .apply(documentationConfiguration(provider)
+                .operationPreprocessors()
+                .withRequestDefaults(prettyPrint())
+                .withResponseDefaults(prettyPrint()))
+            .build();
+
+    testHelper = new TestHelper(mockMvc, objectMapper);
+  }
+
+  @DisplayName("블로그 글 생성 성공")
+  @Test
+  @WithMockCustomUser
+  void createBlogPost_success() throws Exception {
+    // given
+    BlogPostCreateRequest request = new BlogPostCreateRequest("제목", "내용", List.of(1L, 2L));
+    List<BookInfoResponse> books = List.of(
+        new BookInfoResponse(1L, "책 제목 1", "작가 1"),
+        new BookInfoResponse(2L, "책 제목 2", "작가 2")
+    );
+
+    BlogPostResponse response =
+        new BlogPostResponse(
+            1L,
+            "제목",
+            "내용",
+            "author",
+            LocalDateTime.now(),
+            LocalDateTime.now(),
+            books
+        );
+    given(blogPostService.createBlogPost(any(), eq(1L))).willReturn(response);
+
+    // when & then
+    testHelper
+        .postRequest(BASE_URL, request)
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.data.title").value("제목"))
+        .andExpect(jsonPath("$.data.content").value("내용"))
+        .andDo(
+            document(
+                "blog-post/create",
+                requestFields(
+                    fieldWithPath("title").description("블로그 제목"),
+                    fieldWithPath("content").description("블로그 내용"),
+                    fieldWithPath("bookIds").description("연결된 책 ID 목록")),
+                responseFields(
+                    fieldWithPath("success").description("요청 성공 여부"),
+                    fieldWithPath("code").description("응답 코드"),
+                    fieldWithPath("message").description("응답 메시지"),
+                    fieldWithPath("data.id").description("블로그 글 ID"),
+                    fieldWithPath("data.title").description("블로그 글 제목"),
+                    fieldWithPath("data.content").description("블로그 글 내용"),
+                    fieldWithPath("data.authorName").description("작성자 이름"),
+                    fieldWithPath("data.createdAt").description("생성 일시"),
+                    fieldWithPath("data.updatedAt").description("수정 일시"),
+                    fieldWithPath("data.books").description("연결된 책 정보 목록"),
+                    fieldWithPath("data.books[].id").description("책 ID"),
+                    fieldWithPath("data.books[].title").description("책 제목"),
+                    fieldWithPath("data.books[].author").description("책 작가"),
+                    fieldWithPath("errors").description("에러 목록"))));
+  }
+
+  @DisplayName("블로그 글 단건 조회")
+  @Test
+  @WithMockCustomUser
+  void getBlogPost_success() throws Exception {
+    List<BookInfoResponse> books = List.of(
+        new BookInfoResponse(1L, "책 제목 1", "작가 1"),
+        new BookInfoResponse(2L, "책 제목 2", "작가 2")
+    );
+
+    BlogPostResponse response =
+        new BlogPostResponse(
+            1L,
+            "제목",
+            "내용",
+            "author",
+            LocalDateTime.now(),
+            LocalDateTime.now(),
+            books
+        );
+
+    given(blogPostService.getBlogPost(eq(1L), anyLong())).willReturn(response);
+
+    mockMvc
+        .perform(get(BASE_URL + "/{id}", 1L))
+        .andExpect(status().isOk())
+        .andDo(
+            document(
+                "blog-post/get",
+                pathParameters(parameterWithName("id").description("블로그 글 ID")),
+                responseFields(
+                    fieldWithPath("success").description("요청 성공 여부"),
+                    fieldWithPath("code").description("응답 코드"),
+                    fieldWithPath("message").description("응답 메시지"),
+                    fieldWithPath("data.id").description("블로그 글 ID"),
+                    fieldWithPath("data.title").description("블로그 글 제목"),
+                    fieldWithPath("data.content").description("블로그 글 내용"),
+                    fieldWithPath("data.authorName").description("작성자 이름"),
+                    fieldWithPath("data.createdAt").description("생성 일시"),
+                    fieldWithPath("data.updatedAt").description("수정 일시"),
+                    fieldWithPath("data.books").description("연결된 책 정보 목록"),
+                    fieldWithPath("data.books[].id").description("책 ID"),
+                    fieldWithPath("data.books[].title").description("책 제목"),
+                    fieldWithPath("data.books[].author").description("책 작가"),
+                    fieldWithPath("errors").description("에러 목록"))));
+  }
+
+  @DisplayName("공개된 블로그 글 목록 조회")
+  @Test
+  void getPublicPosts() throws Exception {
+    List<BlogPostSimpleResponse> posts =
+        List.of(
+            new BlogPostSimpleResponse(1L, "제목1", "summary1", "author1", LocalDateTime.now()),
+            new BlogPostSimpleResponse(2L, "제목2", "summary2", "author2", LocalDateTime.now()));
+    Page<BlogPostSimpleResponse> page =
+        new PageImpl<>(posts, PageRequest.of(0, 10), posts.size());
+
+    given(blogPostService.getPublicBlogPosts(any(Pageable.class))).willReturn(page);
+
+    Map<String, String> params = Map.of("page", "0", "size", "10");
+
+    testHelper
+        .getRequest(BASE_URL + "/public", params)
+        .andExpect(status().isOk())
+        .andDo(
+            document(
+                "blog-post/list-public",
+                queryParameters(
+                    parameterWithName("page").description("페이지 번호"),
+                    parameterWithName("size").description("페이지 크기")),
+                responseFields(
+                    fieldWithPath("success").description("요청 성공 여부"),
+                    fieldWithPath("code").description("응답 코드"),
+                    fieldWithPath("message").description("응답 메시지"),
+                    fieldWithPath("data.content[].id").description("글 ID"),
+                    fieldWithPath("data.content[].title").description("제목"),
+                    fieldWithPath("data.content[].summary").description("요약"),
+                    fieldWithPath("data.content[].authorName").description("작성자"),
+                    fieldWithPath("data.content[].createdAt").description("작성일"),
+                    fieldWithPath("data.pagination.page").description("현재 페이지 번호"),
+                    fieldWithPath("data.pagination.size").description("페이지 크기"),
+                    fieldWithPath("data.pagination.totalPages").description("전체 페이지 수"),
+                    fieldWithPath("data.pagination.totalElements").description("전체 데이터 수"),
+                    fieldWithPath("data.pagination.first").description("첫 페이지 여부"),
+                    fieldWithPath("data.pagination.last").description("마지막 페이지 여부"),
+                    fieldWithPath("errors").description("에러 목록"))));
+  }
+
+
+  @DisplayName("작성자 블로그 글 목록 조회")
+  @Test
+  void getPostsByAuthor() throws Exception {
+    long authorId = 5L;
+    List<BlogPostSimpleResponse> posts =
+        List.of(
+            new BlogPostSimpleResponse(1L, "제목1", "summary", "author", LocalDateTime.now()));
+    Page<BlogPostSimpleResponse> page = new PageImpl<>(posts, PageRequest.of(0, 10), posts.size());
+
+    given(blogPostService.getPublicPostsByAuthor(eq(authorId), any(Pageable.class)))
+        .willReturn(page);
+
+    mockMvc
+        .perform(
+            get(BASE_URL + "/author/{authorId}", authorId).param("page", "0").param("size", "5"))
+        .andExpect(status().isOk())
+        .andDo(
+            document(
+                "blog-post/list-by-author",
+                pathParameters(parameterWithName("authorId").description("작성자 ID")),
+                queryParameters(
+                    parameterWithName("page").description("페이지 번호"),
+                    parameterWithName("size").description("페이지 크기")),
+                responseFields(
+                    fieldWithPath("success").description("요청 성공 여부"),
+                    fieldWithPath("code").description("응답 코드"),
+                    fieldWithPath("message").description("응답 메시지"),
+                    fieldWithPath("data.content[].id").description("글 ID"),
+                    fieldWithPath("data.content[].title").description("제목"),
+                    fieldWithPath("data.content[].summary").description("요약"),
+                    fieldWithPath("data.content[].authorName").description("작성자"),
+                    fieldWithPath("data.content[].createdAt").description("작성일"),
+                    fieldWithPath("data.pagination.page").description("현재 페이지 번호"),
+                    fieldWithPath("data.pagination.size").description("페이지 크기"),
+                    fieldWithPath("data.pagination.totalPages").description("전체 페이지 수"),
+                    fieldWithPath("data.pagination.totalElements").description("전체 데이터 수"),
+                    fieldWithPath("data.pagination.first").description("첫 페이지 여부"),
+                    fieldWithPath("data.pagination.last").description("마지막 페이지 여부"),
+                    fieldWithPath("errors").description("에러 목록"))));
+  }
+
+  @DisplayName("내 블로그 글 목록 조회")
+  @Test
+  @WithMockCustomUser
+  void getMyPosts_success() throws Exception {
+    List<BlogPostSimpleResponse> posts =
+        List.of(
+            new BlogPostSimpleResponse(1L, "제목1", "summary", "author", LocalDateTime.now()));
+    Page<BlogPostSimpleResponse> page = new PageImpl<>(posts, PageRequest.of(0, 10), posts.size());
+
+    given(blogPostService.getMyBlogPosts(anyLong(), any(Pageable.class)))
+        .willReturn(page);
+
+    mockMvc
+        .perform(get(BASE_URL + "/me").param("page", "0").param("size", "10"))
+        .andExpect(status().isOk())
+        .andDo(document("blog-post/list-my",
+            queryParameters(
+                parameterWithName("page").description("페이지 번호"),
+                parameterWithName("size").description("페이지 크기")),
+            responseFields(
+                fieldWithPath("success").description("요청 성공 여부"),
+                fieldWithPath("code").description("응답 코드"),
+                fieldWithPath("message").description("응답 메시지"),
+                fieldWithPath("data.content[].id").description("글 ID"),
+                fieldWithPath("data.content[].title").description("제목"),
+                fieldWithPath("data.content[].summary").description("요약"),
+                fieldWithPath("data.content[].authorName").description("작성자"),
+                fieldWithPath("data.content[].createdAt").description("작성일"),
+                fieldWithPath("data.pagination.page").description("현재 페이지 번호"),
+                fieldWithPath("data.pagination.size").description("페이지 크기"),
+                fieldWithPath("data.pagination.totalPages").description("전체 페이지 수"),
+                fieldWithPath("data.pagination.totalElements").description("전체 데이터 수"),
+                fieldWithPath("data.pagination.first").description("첫 페이지 여부"),
+                fieldWithPath("data.pagination.last").description("마지막 페이지 여부"),
+                fieldWithPath("errors").description("에러 목록"))));
+  }
+
+  @DisplayName("블로그 글 수정")
+  @Test
+  @WithMockCustomUser
+  void updateBlogPost_success() throws Exception {
+    BlogPostUpdateRequest request = new BlogPostUpdateRequest("수정된 제목", "수정된 내용", List.of(1L, 2L));
+    List<BookInfoResponse> books = List.of(
+        new BookInfoResponse(1L, "책 제목 1", "작가 1"),
+        new BookInfoResponse(2L, "책 제목 2", "작가 2")
+    );
+
+    BlogPostResponse response =
+        new BlogPostResponse(
+            1L,
+            "수정된 제목",
+            "수정된 내용",
+            "author",
+            LocalDateTime.now(),
+            LocalDateTime.now(),
+            books
+        );
+
+    given(blogPostService.updateBlogPost(eq(1L), any(), anyLong())).willReturn(response);
+
+    mockMvc
+        .perform(
+            put(BASE_URL + "/{id}", 1L)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isOk())
+        .andDo(
+            document(
+                "blog-post/update",
+                pathParameters(parameterWithName("id").description("블로그 ID")),
+                requestFields(
+                    fieldWithPath("title").description("제목"),
+                    fieldWithPath("content").description("내용"),
+                    fieldWithPath("bookIds").description("책 ID 목록")),
+                responseFields(
+                    fieldWithPath("success").description("요청 성공 여부"),
+                    fieldWithPath("code").description("응답 코드"),
+                    fieldWithPath("message").description("응답 메시지"),
+                    fieldWithPath("data.id").description("블로그 글 ID"),
+                    fieldWithPath("data.title").description("블로그 글 제목"),
+                    fieldWithPath("data.content").description("블로그 글 내용"),
+                    fieldWithPath("data.authorName").description("작성자 이름"),
+                    fieldWithPath("data.createdAt").description("생성 일시"),
+                    fieldWithPath("data.updatedAt").description("수정 일시"),
+                    fieldWithPath("data.books").description("연결된 책 정보 목록"),
+                    fieldWithPath("data.books[].id").description("책 ID"),
+                    fieldWithPath("data.books[].title").description("책 제목"),
+                    fieldWithPath("data.books[].author").description("책 작가"),
+                    fieldWithPath("errors").description("에러 목록"))));
+  }
+
+  @DisplayName("블로그 글 삭제")
+  @Test
+  @WithMockCustomUser
+  void deleteBlogPost_success() throws Exception {
+    doNothing().when(blogPostService).deleteBlogPost(eq(1L), anyLong());
+
+    mockMvc
+        .perform(delete(BASE_URL + "/{id}", 1L))
+        .andExpect(status().isNoContent())
+        .andDo(
+            document(
+                "blog-post/delete",
+                pathParameters(parameterWithName("id").description("삭제할 블로그 ID"))));
+  }
+}

--- a/src/test/java/com/clover/bookflow/domain/blogpost/entity/BlogPostTest.java
+++ b/src/test/java/com/clover/bookflow/domain/blogpost/entity/BlogPostTest.java
@@ -1,0 +1,145 @@
+package com.clover.bookflow.domain.blogpost.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.clover.bookflow.domain.blogpost.enums.BlogPostState;
+import com.clover.bookflow.domain.book.entity.Book;
+import com.clover.bookflow.domain.book.entity.BookTestHelper;
+import com.clover.bookflow.domain.member.entity.Member;
+import com.clover.bookflow.domain.member.entity.MemberTestHelper;
+import com.clover.bookflow.global.errorcode.BlogPostErrorCode;
+import com.clover.bookflow.global.exception.BusinessException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class BlogPostTest {
+
+  private Member author;
+  private Member admin;
+  private Member otherUser;
+
+  @BeforeEach
+  void setUp() {
+    author = MemberTestHelper.createTestUser();
+    admin = MemberTestHelper.createTestAdmin();
+    otherUser = MemberTestHelper.createTestOtherUser();
+  }
+
+  @Test
+  void testCreateDraft() {
+    BlogPost post = BlogPost.createDraft("Title", "Content", author);
+
+    assertThat(post.getTitle()).isEqualTo("Title");
+    assertThat(post.getContent()).isEqualTo("Content");
+    assertThat(post.getState()).isEqualTo(BlogPostState.DRAFT);
+    assertThat(post.getAuthor()).isEqualTo(author);
+  }
+
+  @Test
+  void testCreatePublished() {
+    BlogPost post = BlogPost.createPublished("Title", "Content", author);
+
+    assertThat(post.getState()).isEqualTo(BlogPostState.ACTIVE);
+  }
+
+  @Test
+  void testUpdateContent() {
+    BlogPost post = BlogPost.createDraft("Old Title", "Old Content", author);
+    post.update("New Title", "New Content");
+
+    assertThat(post.getTitle()).isEqualTo("New Title");
+    assertThat(post.getContent()).isEqualTo("New Content");
+  }
+
+  @Test
+  void testUpdateDeletedPost_throwsException() {
+    BlogPost post = BlogPostTestHelper.createDraftPost(author);
+    post.delete();
+
+    assertThatThrownBy(() -> post.update("X", "Y"))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("삭제된 글은 수정할 수 없습니다.");
+  }
+
+  @Test
+  void testStateTransitions() {
+    BlogPost post = BlogPostTestHelper.createDraftPost(author);
+
+    post.publish();
+    assertThat(post.getState()).isEqualTo(BlogPostState.ACTIVE);
+
+    post.makePrivate();
+    assertThat(post.getState()).isEqualTo(BlogPostState.PRIVATE);
+
+    post.delete();
+    assertThat(post.getState()).isEqualTo(BlogPostState.DELETED);
+  }
+
+  @Test
+  void testInvalidStateTransition_throwsException() {
+    BlogPost post = BlogPostTestHelper.createDraftPost(author);
+    post.delete();
+
+    assertThatThrownBy(post::publish)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("상태 전환 불가");
+  }
+
+  @Test
+  void testAddAndRemoveBooks() {
+    BlogPost post = BlogPostTestHelper.createDraftPost(author);
+    Book book1 = BookTestHelper.createBookWithDetail();
+    Book book2 = BookTestHelper.createBook();
+
+    post.addBook(book1);
+    post.addBook(book1);
+    assertThat(post.getBlogPostBooks()).hasSize(1);
+
+    post.addBook(book2);
+    assertThat(post.getBlogPostBooks()).hasSize(2);
+
+    post.removeBook(book1);
+    assertThat(post.getBlogPostBooks()).hasSize(1);
+  }
+
+  @Test
+  void testIsAccessibleBy() {
+    BlogPost post = BlogPost.createDraft("Title", "Content", author);
+
+    // 작성자와 관리자 접근 가능
+    assertThat(post.isAccessibleBy(author)).isTrue();
+    assertThat(post.isAccessibleBy(admin)).isTrue();
+
+    // 일반 유저는 DRAFT 접근 불가
+    assertThat(post.isAccessibleBy(otherUser)).isFalse();
+
+    // 상태를 ACTIVE로 바꾸면 모든 사용자 접근 가능
+    post.publish();
+    assertThat(post.isAccessibleBy(otherUser)).isTrue();
+  }
+
+  @Test
+  void testValidateAccessibleBy_throwsException() {
+    BlogPost post = BlogPost.createDraft("Title", "Content", author);
+
+    assertThatThrownBy(() -> post.validateAccessibleBy(otherUser))
+        .isInstanceOf(BusinessException.class)
+        .hasMessage(BlogPostErrorCode.UNAUTHORIZED_ACCESS.getMessage());
+  }
+
+  @Test
+  void testIsXXXMethods() {
+    BlogPost post = BlogPost.createDraft("Title", "Content", author);
+    assertThat(post.isDraft()).isTrue();
+
+    post.publish();
+    assertThat(post.isActive()).isTrue();
+
+    post.makePrivate();
+    assertThat(post.isPrivate()).isTrue();
+
+    post.delete();
+    assertThat(post.isDeleted()).isTrue();
+  }
+}

--- a/src/test/java/com/clover/bookflow/domain/blogpost/entity/BlogPostTestHelper.java
+++ b/src/test/java/com/clover/bookflow/domain/blogpost/entity/BlogPostTestHelper.java
@@ -1,0 +1,21 @@
+package com.clover.bookflow.domain.blogpost.entity;
+
+import com.clover.bookflow.domain.member.entity.Member;
+
+public class BlogPostTestHelper {
+
+  public static BlogPost createDraftPost(Member author) {
+    return BlogPost.createDraft("Draft Title", "Draft Content", author);
+  }
+
+  public static BlogPost createPublishedPost(Member author) {
+    return BlogPost.createPublished("Published Title", "Published Content", author);
+  }
+
+  public static BlogPost createDeletedPost(Member author) {
+    BlogPost post = createDraftPost(author);
+    post.delete();
+    return post;
+  }
+
+}

--- a/src/test/java/com/clover/bookflow/domain/blogpost/service/BlogPostServiceTest.java
+++ b/src/test/java/com/clover/bookflow/domain/blogpost/service/BlogPostServiceTest.java
@@ -1,0 +1,319 @@
+package com.clover.bookflow.domain.blogpost.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import com.clover.bookflow.domain.blogpost.dto.request.BlogPostCreateRequest;
+import com.clover.bookflow.domain.blogpost.dto.request.BlogPostUpdateRequest;
+import com.clover.bookflow.domain.blogpost.dto.response.BlogPostResponse;
+import com.clover.bookflow.domain.blogpost.dto.response.BlogPostSimpleResponse;
+import com.clover.bookflow.domain.blogpost.entity.BlogPost;
+import com.clover.bookflow.domain.blogpost.enums.BlogPostState;
+import com.clover.bookflow.domain.blogpost.repository.BlogPostRepository;
+import com.clover.bookflow.domain.book.entity.Book;
+import com.clover.bookflow.domain.book.entity.BookTestHelper;
+import com.clover.bookflow.domain.book.repository.BookRepository;
+import com.clover.bookflow.domain.member.entity.Member;
+import com.clover.bookflow.domain.member.entity.MemberTestHelper;
+import com.clover.bookflow.domain.member.repository.MemberRepository;
+import com.clover.bookflow.global.errorcode.BlogPostErrorCode;
+import com.clover.bookflow.global.errorcode.BookErrorCode;
+import com.clover.bookflow.global.exception.BusinessException;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+@ExtendWith(MockitoExtension.class)
+class BlogPostServiceTest {
+
+  @Mock
+  private BlogPostRepository blogPostRepository;
+  @Mock
+  private MemberRepository memberRepository;
+  @Mock
+  private BookRepository bookRepository;
+
+  @InjectMocks
+  private BlogPostService blogPostService;
+
+  private Member author;
+
+  @BeforeEach
+  void setUp() {
+    author = MemberTestHelper.createTestUser();
+  }
+
+  @Nested
+  class CreateTests {
+
+    @Test
+    void createBlogPost_success() {
+      // given
+      BlogPostCreateRequest createRequest = new BlogPostCreateRequest("Test Title", "Test Content",
+          List.of(1L, 2L));
+      given(memberRepository.findById(1L)).willReturn(Optional.of(author));
+
+      List<Book> books = BookTestHelper.mockBooks(1L, 2L);
+      given(bookRepository.findAllById(createRequest.bookIds())).willReturn(books);
+
+      // when
+      BlogPostResponse response = blogPostService.createBlogPost(createRequest, 1L);
+
+      // then
+      assertThat(response.title()).isEqualTo("Test Title");
+      assertThat(response.content()).isEqualTo("Test Content");
+      verify(blogPostRepository).save(any(BlogPost.class));
+    }
+
+    @Test
+    void createBlogPost_whenBookMissing_thenThrow() {
+      BlogPostCreateRequest req = new BlogPostCreateRequest("Title", "Content", List.of(1L, 2L));
+      given(memberRepository.findById(1L)).willReturn(Optional.of(author));
+
+      List<Book> foundBooks = List.of(BookTestHelper.createBook());
+      given(bookRepository.findAllById(req.bookIds())).willReturn(foundBooks);
+
+      assertThatThrownBy(() -> blogPostService.createBlogPost(req, 1L))
+          .isInstanceOf(BusinessException.class)
+          .satisfies(ex -> {
+            BusinessException be = (BusinessException) ex;
+            assertThat(be.getErrorCode()).isEqualTo(BookErrorCode.BOOK_NOT_FOUND);
+          });
+
+      verify(blogPostRepository, never()).save(any());
+    }
+  }
+
+  @Nested
+  class ReadTests {
+
+    @Test
+    void getBlogPost_success_whenActive() {
+      BlogPost blogPost = mock(BlogPost.class);
+      given(blogPostRepository.findByIdAndStateNot(1L, BlogPostState.DELETED))
+          .willReturn(Optional.of(blogPost));
+
+      given(blogPost.getAuthor()).willReturn(author);
+
+      BlogPostService spyService = spy(blogPostService);
+      doReturn(true).when(spyService).canViewBlogPost(blogPost, 1L);
+
+      given(blogPost.getTitle()).willReturn("Title X");
+      given(blogPost.getContent()).willReturn("Content X");
+
+      BlogPostResponse resp = spyService.getBlogPost(1L, 1L);
+
+      assertThat(resp.title()).isEqualTo("Title X");
+      assertThat(resp.content()).isEqualTo("Content X");
+      verify(blogPostRepository).findByIdAndStateNot(1L, BlogPostState.DELETED);
+    }
+
+    @Test
+    void getBlogPost_whenUnauthorized_thenThrow() {
+      BlogPost blogPost = mock(BlogPost.class);
+      given(blogPostRepository.findByIdAndStateNot(1L, BlogPostState.DELETED))
+          .willReturn(Optional.of(blogPost));
+
+      BlogPostService spyService = spy(blogPostService);
+      doReturn(false).when(spyService).canViewBlogPost(blogPost, 1L);
+
+      assertThatThrownBy(() -> spyService.getBlogPost(1L, 1L))
+          .isInstanceOf(BusinessException.class)
+          .satisfies(ex -> {
+            BusinessException be = (BusinessException) ex;
+            assertThat(be.getErrorCode()).isEqualTo(BlogPostErrorCode.UNAUTHORIZED_ACCESS);
+          });
+    }
+
+    @Test
+    void getBlogPost_whenNotFound_thenThrow() {
+      given(blogPostRepository.findByIdAndStateNot(1L, BlogPostState.DELETED))
+          .willReturn(Optional.empty());
+
+      assertThatThrownBy(() -> blogPostService.getBlogPost(1L, 1L))
+          .isInstanceOf(BusinessException.class)
+          .satisfies(ex -> {
+            BusinessException be = (BusinessException) ex;
+            assertThat(be.getErrorCode()).isEqualTo(BlogPostErrorCode.BLOG_POST_NOT_FOUND);
+          });
+    }
+  }
+
+  @Nested
+  class UpdateTests {
+
+    @Test
+    void updateBlogPost_success() {
+      BlogPost blogPost = mock(BlogPost.class);
+      given(blogPostRepository.findByIdAndStateNot(1L, BlogPostState.DELETED))
+          .willReturn(Optional.of(blogPost));
+
+      given(blogPost.getAuthor()).willReturn(author);
+
+      BlogPostUpdateRequest dto = new BlogPostUpdateRequest("New Title", "New Content", List.of());
+      BlogPostService spyService = spy(blogPostService);
+      doReturn(true).when(spyService).hasPermission(blogPost, 1L);
+
+      given(blogPost.getTitle()).willReturn("New Title");
+      given(blogPost.getContent()).willReturn("New Content");
+
+      BlogPostResponse resp = spyService.updateBlogPost(1L, dto, 1L);
+
+      assertThat(resp.title()).isEqualTo("New Title");
+      assertThat(resp.content()).isEqualTo("New Content");
+    }
+
+    @Test
+    void updateBlogPost_whenNoPermission_thenThrow() {
+      BlogPost blogPost = mock(BlogPost.class);
+      given(blogPostRepository.findByIdAndStateNot(1L, BlogPostState.DELETED))
+          .willReturn(Optional.of(blogPost));
+
+      BlogPostService spyService = spy(blogPostService);
+      doReturn(false).when(spyService).hasPermission(blogPost, 2L);
+
+      BlogPostUpdateRequest dto = new BlogPostUpdateRequest("New Title", "New Content", List.of());
+
+      assertThatThrownBy(() -> spyService.updateBlogPost(1L, dto, 2L))
+          .isInstanceOf(BusinessException.class)
+          .satisfies(ex -> {
+            BusinessException be = (BusinessException) ex;
+            assertThat(be.getErrorCode()).isEqualTo(BlogPostErrorCode.UNAUTHORIZED_ACCESS);
+          });
+    }
+  }
+
+  @Nested
+  class DeleteTests {
+
+    @Test
+    void deleteBlogPost_success() {
+      BlogPost blogPost = mock(BlogPost.class);
+      given(blogPostRepository.findByIdAndStateNot(1L, BlogPostState.DELETED))
+          .willReturn(Optional.of(blogPost));
+
+      BlogPostService spyService = spy(blogPostService);
+      doReturn(true).when(spyService).hasPermission(blogPost, 1L);
+
+      spyService.deleteBlogPost(1L, 1L);
+
+      verify(blogPost).delete();
+    }
+
+    @Test
+    void deleteBlogPost_whenNoPermission_thenThrow() {
+      BlogPost blogPost = mock(BlogPost.class);
+      given(blogPostRepository.findByIdAndStateNot(1L, BlogPostState.DELETED))
+          .willReturn(Optional.of(blogPost));
+
+      BlogPostService spyService = spy(blogPostService);
+      doReturn(false).when(spyService).hasPermission(blogPost, 1L);
+
+      assertThatThrownBy(() -> spyService.deleteBlogPost(1L, 1L))
+          .isInstanceOf(BusinessException.class)
+          .satisfies(ex -> {
+            BusinessException be = (BusinessException) ex;
+            assertThat(be.getErrorCode()).isEqualTo(BlogPostErrorCode.UNAUTHORIZED_ACCESS);
+          });
+    }
+  }
+
+  @Nested
+  class QueryTests {
+
+    @Test
+    void getPublicBlogPosts_whenPostsExist_thenReturnList() {
+      BlogPost post = BlogPost.createPublished("제목", "내용", author);
+      Page<BlogPost> page = new PageImpl<>(List.of(post));
+      given(blogPostRepository.findByState(BlogPostState.ACTIVE, Pageable.unpaged()))
+          .willReturn(page);
+
+      Page<BlogPostSimpleResponse> result = blogPostService.getPublicBlogPosts(Pageable.unpaged());
+
+      assertThat(result.getContent()).hasSize(1);
+      assertThat(result.getContent().getFirst().title()).isEqualTo("제목");
+    }
+
+    @Test
+    void getPublicBlogPosts_empty() {
+      Page<BlogPost> emptyPage = Page.empty();
+      given(blogPostRepository.findByState(eq(BlogPostState.ACTIVE), any(Pageable.class)))
+          .willReturn(emptyPage);
+
+      Page<BlogPostSimpleResponse> result = blogPostService.getPublicBlogPosts(Pageable.unpaged());
+
+      assertThat(result.getContent()).isEmpty();
+    }
+
+    @Test
+    void getPublicPostsByAuthor_whenPostsExist_thenReturnList() {
+      BlogPost post = BlogPost.createPublished("작성자 글", "내용", author);
+      Page<BlogPost> page = new PageImpl<>(List.of(post));
+      given(blogPostRepository.findByAuthorIdAndState(1L, BlogPostState.ACTIVE, Pageable.unpaged()))
+          .willReturn(page);
+
+      Page<BlogPostSimpleResponse> result = blogPostService.getPublicPostsByAuthor(1L,
+          Pageable.unpaged());
+
+      assertThat(result.getContent()).hasSize(1);
+      assertThat(result.getContent().getFirst().title()).isEqualTo("작성자 글");
+    }
+
+    @Test
+    void getPublicPostsByAuthor_empty() {
+      Page<BlogPost> emptyPage = Page.empty();
+      given(
+          blogPostRepository.findByAuthorIdAndState(eq(1L), eq(BlogPostState.ACTIVE),
+              any(Pageable.class)))
+          .willReturn(emptyPage);
+
+      var result = blogPostService.getPublicPostsByAuthor(1L, Pageable.unpaged());
+
+      assertThat(result.getContent()).isEmpty();
+    }
+
+    @Test
+    void getMyBlogPosts_whenPostsExist_thenReturnList() {
+      BlogPost post = BlogPost.createPublished("내 글", "내용", author);
+      Page<BlogPost> page = new PageImpl<>(List.of(post));
+      given(
+          blogPostRepository.findByAuthorIdAndStateNot(1L, BlogPostState.DELETED,
+              Pageable.unpaged()))
+          .willReturn(page);
+
+      var result = blogPostService.getMyBlogPosts(1L, Pageable.unpaged());
+
+      assertThat(result.getContent()).hasSize(1);
+      assertThat(result.getContent().getFirst().title()).isEqualTo("내 글");
+    }
+
+    @Test
+    void getMyBlogPosts_empty() {
+      Page<BlogPost> emptyPage = Page.empty();
+      given(blogPostRepository.findByAuthorIdAndStateNot(eq(1L), eq(BlogPostState.DELETED),
+          any(Pageable.class)))
+          .willReturn(emptyPage);
+
+      var result = blogPostService.getMyBlogPosts(1L, Pageable.unpaged());
+
+      assertThat(result.getContent()).isEmpty();
+    }
+  }
+}

--- a/src/test/java/com/clover/bookflow/domain/book/entity/BookTestHelper.java
+++ b/src/test/java/com/clover/bookflow/domain/book/entity/BookTestHelper.java
@@ -1,0 +1,86 @@
+package com.clover.bookflow.domain.book.entity;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * 테스트에서 사용할 Book 관련 도우미 클래스. - 실제 Book 객체 생성 (도메인 테스트, 통합 테스트) - mock Book 객체 생성 (단위 테스트용 stub)
+ */
+public class BookTestHelper {
+
+  // 실제 객체 생성 (new Book(...))
+
+  public static Book createBook() {
+    return new Book(
+        "978-89-01-12345-6",
+        "테스트 책 제목",
+        "홍길동",
+        "테스트출판사",
+        "https://example.com/cover.jpg",
+        LocalDate.of(2020, 1, 1),
+        "이 책은 테스트용입니다.",
+        "프로그래밍"
+    );
+  }
+
+  public static Book createBookWithDetail() {
+    Book book = createBook();
+    BookDetail bookDetail = new BookDetail(book);
+    book.changeBookDetail(bookDetail);  // 양방향 연관관계 설정
+    return book;
+  }
+
+  public static BookDetail createBookDetail(Book book) {
+    BookDetail bookDetail = new BookDetail(book);
+    book.changeBookDetail(bookDetail); // 양방향 연관관계 설정
+    return bookDetail;
+  }
+
+  public static BookDetail createFullBookDetail(Book book) {
+    BookDetail bookDetail = createBookDetail(book);
+
+    bookDetail.updateDetail(
+        "100", // ddc
+        "200", // kdc
+        "https://example.com/toc",
+        "목차 내용입니다",
+        "https://example.com/intro",
+        "책 소개입니다",
+        "https://example.com/summary",
+        "요약입니다",
+        "프로그래밍",
+        "350"
+    );
+
+    return bookDetail;
+  }
+
+  public static Book createBookWithFullDetail() {
+    Book book = createBook();
+    BookDetail fullDetail = createFullBookDetail(book);
+    book.changeBookDetail(fullDetail);
+    return book;
+  }
+
+  // Mockito mock 객체 생성
+
+  public static Book mockBook(Long id) {
+    Book book = mock(Book.class);
+    when(book.getId()).thenReturn(id);
+    when(book.getTitle()).thenReturn("Mock 책 " + id);
+    when(book.getAuthor()).thenReturn("Mock 저자");
+    // 필요한 메서드 추가 stub 가능
+    return book;
+  }
+
+  public static List<Book> mockBooks(Long... ids) {
+    return Arrays.stream(ids)
+        .map(BookTestHelper::mockBook)
+        .collect(Collectors.toList());
+  }
+}

--- a/src/test/java/com/clover/bookflow/domain/member/entity/MemberTestHelper.java
+++ b/src/test/java/com/clover/bookflow/domain/member/entity/MemberTestHelper.java
@@ -28,18 +28,31 @@ public class MemberTestHelper {
   public static Member createTestUser(UUID uuid, String email, String password, String nickname,
       Role role, MemberStatus status) {
     return new Member(uuid, email, password, nickname, role, status);
-        DEFAULT_NICKNAME, Role.USER);
+  }
+
+  public static Member createTestMemberWithId(
+      Long id,
+      UUID uuid,
+      String email,
+      String password,
+      String nickname,
+      Role role,
+      MemberStatus status
+  ) {
+    return new Member(id, uuid, email, password, nickname, role, status);
   }
 
   public static Member createTestOtherUser() {
     UUID testUuid = UUID.randomUUID();
-    return new Member(testUuid, "other@example.com", "otherpassword&", "otherNickname", Role.USER, MemberStatus.ACTIVE);
+    return new Member(testUuid, "other@example.com", "otherpassword&", "otherNickname", Role.USER,
+        MemberStatus.ACTIVE);
   }
 
 
   public static Member createTestAdmin() {
     UUID testUuid = UUID.randomUUID();
-    return new Member(testUuid, ADMIN_EMAIL, ADMIN_PASSWORD, ADMIN_NICKNAME, Role.ADMIN, MemberStatus.ACTIVE);
+    return new Member(testUuid, ADMIN_EMAIL, ADMIN_PASSWORD, ADMIN_NICKNAME, Role.ADMIN,
+        MemberStatus.ACTIVE);
   }
 
 

--- a/src/test/java/com/clover/bookflow/domain/member/entity/MemberTestHelper.java
+++ b/src/test/java/com/clover/bookflow/domain/member/entity/MemberTestHelper.java
@@ -1,5 +1,6 @@
 package com.clover.bookflow.domain.member.entity;
 
+import com.clover.bookflow.domain.member.enums.Role;
 import java.util.UUID;
 
 public class MemberTestHelper {
@@ -7,6 +8,10 @@ public class MemberTestHelper {
   private static final String DEFAULT_EMAIL = "test@example.com";
   private static final String DEFAULT_PASSWORD = "password123";
   private static final String DEFAULT_NICKNAME = "testNickname";
+
+  private static final String ADMIN_EMAIL = "admin@example.com";
+  private static final String ADMIN_PASSWORD = "password456";
+  private static final String ADMIN_NICKNAME = "testAdmin";
 
 //  public static Member createTestUser() {
 //    return new Member(DEFAULT_EMAIL, DEFAULT_PASSWORD,
@@ -16,7 +21,18 @@ public class MemberTestHelper {
   public static Member createTestUser() {
     UUID testUuid = UUID.randomUUID();
     return new Member(testUuid, DEFAULT_EMAIL, DEFAULT_PASSWORD,
-        DEFAULT_NICKNAME);
+        DEFAULT_NICKNAME, Role.USER);
+  }
+
+  public static Member createTestOtherUser() {
+    UUID testUuid = UUID.randomUUID();
+    return new Member(testUuid, "other@example.com", "otherpassword&", "otherNickname", Role.USER);
+  }
+
+
+  public static Member createTestAdmin() {
+    UUID testUuid = UUID.randomUUID();
+    return new Member(testUuid, ADMIN_EMAIL, ADMIN_PASSWORD, ADMIN_NICKNAME, Role.ADMIN);
   }
 
 


### PR DESCRIPTION
# [#43] 독서 블로그 기능 구현

---

## 📌 개요

블로그 게시글(BlogPost) 관련 CRUD 기능을 구현하였습니다.  
해당 기능을 위해 엔티티, DTO, 서비스, 컨트롤러, 보안 설정 및 테스트 코드 등을 전반적으로 추가/수정하였습니다.

---

## ✨ 주요 변경 사항

- `BlogPost`, `BlogPostBook`, `ReadBook` 엔티티 추가 및 관계 매핑
- `BlogPost` ↔ `Member` 엔티티 간 연관관계 설정
- `BlogPost` 관련 Request / Response DTO 추가 및 필드 유효성 검증 애노테이션 적용
- `BlogPostService`, `BlogPostRepository` 구현
- `BlogPostErrorCode` 등 도메인 에러 코드 정의
- `BlogPostController` 구현 및 응답 구조 표준화
- `BlogPostPermissionEvaluator` 추가 (권한 확인 로직)
- 메서드 보안 적용을 위한 `@EnableMethodSecurity` 수정
- 테스트용 `Member` 생성자(id 포함) 추가 및 테스트 헬퍼 작성
- `BlogPostServiceTest`, `BlogPostControllerTest` 추가

---

## ✅ 테스트

- 단위 테스트: `BlogPostTest`, `BlogPostServiceTest`, `BlogPostControllerTest`
- 주요 시나리오 기반 테스트 완료
  - 게시글 생성, 조회, 수정, 삭제

---

## 🔖 참고

- 메서드 시큐리티 설정 수정: `@EnableMethodSecurity`
- 테스트 시 ID 포함 `Member` 객체를 위한 테스트용 생성자 추가

---

## 📝 기타

- 커밋 메시지 중 `feat(test)` → `test(domain)` 으로 표현해야 하는 부분이 있음.
- 코드에는 영향 없음.
- 이후 커밋부터는 올바른 prefix 사용 예정.

---

## 🔗 관련 이슈

Closes #43 
Closes #45 