### PR TITLE
[Feature] 사용자 읽은 도서 등록 기능 구현

### DIFF
--- a/src/main/java/com/clover/bookflow/domain/book/dto/BookInfoDto.java
+++ b/src/main/java/com/clover/bookflow/domain/book/dto/BookInfoDto.java
@@ -1,0 +1,9 @@
+package com.clover.bookflow.domain.book.dto;
+
+public record BookInfoDto(
+    Long id,
+    String title,
+    String author
+) {
+
+}

--- a/src/main/java/com/clover/bookflow/domain/book/service/BookService.java
+++ b/src/main/java/com/clover/bookflow/domain/book/service/BookService.java
@@ -102,5 +102,11 @@ public class BookService {
     return bookRepository.findExistingIsbns(isbns);
   }
 
+
+  public Book findOrCreateBookByIsbn(String isbn) {
+    return null;
+    //Todo: Book, BookDetail 구조 리팩토링 진행 및 전체 패키지 구조 리팩토링 진행
+  }
+
   // 도서 조회
 }

--- a/src/main/java/com/clover/bookflow/domain/member/service/MemberService.java
+++ b/src/main/java/com/clover/bookflow/domain/member/service/MemberService.java
@@ -4,6 +4,7 @@ import com.clover.bookflow.domain.auth.dto.request.SignupRequest;
 import com.clover.bookflow.domain.member.entity.Member;
 import com.clover.bookflow.domain.member.repository.MemberRepository;
 import com.clover.bookflow.global.errorcode.MemberErrorCode;
+import com.clover.bookflow.global.exception.BusinessException;
 import com.clover.bookflow.global.exception.DuplicateResourceException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -49,6 +50,12 @@ public class MemberService {
     if (memberRepository.existsByNickname(nickname)) {
       throw new DuplicateResourceException(MemberErrorCode.NICKNAME_ALREADY_EXISTS);
     }
+  }
+
+  @Transactional(readOnly = true)
+  public Member findMemberById(Long memberId) {
+    return memberRepository.findById(memberId)
+        .orElseThrow(() -> new BusinessException(MemberErrorCode.MEMBER_NOT_FOUND));
   }
 
 

--- a/src/main/java/com/clover/bookflow/domain/readbook/dto/request/CreateReadBookRequest.java
+++ b/src/main/java/com/clover/bookflow/domain/readbook/dto/request/CreateReadBookRequest.java
@@ -1,0 +1,15 @@
+package com.clover.bookflow.domain.readbook.dto.request;
+
+import java.time.LocalDate;
+
+public record CreateReadBookRequest(
+    String isbn,
+    String title,
+    String author,
+    String publisher,
+    String publishedDate,
+    String coverUrl,
+    LocalDate readDate
+) {
+
+}

--- a/src/main/java/com/clover/bookflow/domain/readbook/dto/response/ReadBookResponse.java
+++ b/src/main/java/com/clover/bookflow/domain/readbook/dto/response/ReadBookResponse.java
@@ -1,0 +1,29 @@
+package com.clover.bookflow.domain.readbook.dto.response;
+
+import com.clover.bookflow.domain.book.entity.Book;
+import com.clover.bookflow.domain.readbook.entity.ReadBook;
+import java.time.LocalDate;
+
+public record ReadBookResponse(
+    Long readBookId,
+    Long memberId,
+    Long bookId,
+    String title,
+    String author,
+    String coverImgUrl,
+    LocalDate readDate
+) {
+
+  public static ReadBookResponse from(ReadBook readBook) {
+    Book book = readBook.getBook();
+    return new ReadBookResponse(
+        readBook.getId(),
+        readBook.getMember().getId(),
+        book.getId(),
+        book.getTitle(),
+        book.getAuthor(),
+        book.getCoverImgUrl(),
+        readBook.getReadDate()
+    );
+  }
+}

--- a/src/main/java/com/clover/bookflow/domain/readbook/entity/ReadBook.java
+++ b/src/main/java/com/clover/bookflow/domain/readbook/entity/ReadBook.java
@@ -11,6 +11,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import java.time.LocalDate;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -33,9 +34,16 @@ public class ReadBook extends BaseTimeEntity { // 사용자가 읽은 도서 목
   @JoinColumn(name = "book_id")
   private Book book;
 
-  public ReadBook(Member member, Book book) {
+  private LocalDate readDate;
+
+  private ReadBook(Member member, Book book, LocalDate readDate) {
     this.member = member;
     this.book = book;
+    this.readDate = readDate;
+  }
+
+  public static ReadBook create(Member member, Book book, LocalDate readDate) {
+    return new ReadBook(member, book, readDate);
   }
 
 }

--- a/src/main/java/com/clover/bookflow/domain/readbook/repository/ReadBookRepository.java
+++ b/src/main/java/com/clover/bookflow/domain/readbook/repository/ReadBookRepository.java
@@ -1,0 +1,8 @@
+package com.clover.bookflow.domain.readbook.repository;
+
+import com.clover.bookflow.domain.readbook.entity.ReadBook;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReadBookRepository extends JpaRepository<ReadBook, Long> {
+
+}

--- a/src/main/java/com/clover/bookflow/domain/readbook/service/ReadBookService.java
+++ b/src/main/java/com/clover/bookflow/domain/readbook/service/ReadBookService.java
@@ -1,0 +1,43 @@
+package com.clover.bookflow.domain.readbook.service;
+
+import com.clover.bookflow.domain.book.entity.Book;
+import com.clover.bookflow.domain.book.service.BookService;
+import com.clover.bookflow.domain.member.entity.Member;
+import com.clover.bookflow.domain.member.service.MemberService;
+import com.clover.bookflow.domain.readbook.dto.request.CreateReadBookRequest;
+import com.clover.bookflow.domain.readbook.dto.response.ReadBookResponse;
+import com.clover.bookflow.domain.readbook.entity.ReadBook;
+import com.clover.bookflow.domain.readbook.repository.ReadBookRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ReadBookService {
+
+  private final ReadBookRepository readBookRepository;
+  private final MemberService memberService;
+  private final BookService bookService;
+
+  @Transactional
+  public ReadBookResponse addReadBook(CreateReadBookRequest request, Long memberId) {
+    // 1. 회원 조회
+    Member member = memberService.findMemberById(memberId);
+
+    // 2. 책 조회 (DB에 없으면 API 호출 후 저장)
+    Book book = bookService.findOrCreateBookByIsbn(request.isbn());
+
+    // 3. 읽은 책 엔티티 생성 (중복 체크는 ReadBookRepository에서 별도 처리하거나 unique 제약조건 활용)
+    ReadBook readBook = ReadBook.create(member, book, request.readDate());
+
+    // 4. 저장
+    readBookRepository.save(readBook);
+
+    // 5. DTO 변환 후 반환
+    return ReadBookResponse.from(readBook);
+  }
+
+}

--- a/src/test/java/com/clover/bookflow/domain/readbook/service/ReadBookServiceTest.java
+++ b/src/test/java/com/clover/bookflow/domain/readbook/service/ReadBookServiceTest.java
@@ -1,0 +1,110 @@
+package com.clover.bookflow.domain.readbook.service;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import com.clover.bookflow.domain.book.entity.Book;
+import com.clover.bookflow.domain.book.entity.BookTestHelper;
+import com.clover.bookflow.domain.book.service.BookService;
+import com.clover.bookflow.domain.member.entity.Member;
+import com.clover.bookflow.domain.member.entity.MemberTestHelper;
+import com.clover.bookflow.domain.member.service.MemberService;
+import com.clover.bookflow.domain.readbook.dto.request.CreateReadBookRequest;
+import com.clover.bookflow.domain.readbook.dto.response.ReadBookResponse;
+import com.clover.bookflow.domain.readbook.entity.ReadBook;
+import com.clover.bookflow.domain.readbook.repository.ReadBookRepository;
+import java.time.LocalDate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ReadBookServiceTest {
+
+  @Mock
+  private MemberService memberService;
+
+  @Mock
+  private BookService bookService;
+
+  @Mock
+  private ReadBookRepository readBookRepository;
+
+  @InjectMocks
+  private ReadBookService readBookService;
+
+  @Nested
+  @DisplayName("addReadBook 메서드 테스트")
+  class AddReadBookTests {
+
+    @DisplayName("도서가 DB에 없는 경우, 도서를 생성하고 읽은 책 등록에 성공한다")
+    @Test
+    void shouldCreateBookAndSaveReadBook_whenBookNotExist() {
+      // given
+      Long memberId = 1L;
+      CreateReadBookRequest request = new CreateReadBookRequest(
+          "1234567890",    // isbn
+          "testtitle",     // title
+          "testauthor",
+          "testpublisher",
+          "2023-01-01",
+          "http://testcover.url",
+          LocalDate.now()
+      );
+
+      Member member = MemberTestHelper.createTestUser();
+      Book newBook = BookTestHelper.createBook();
+
+      given(memberService.findMemberById(memberId)).willReturn(member);
+      given(bookService.findOrCreateBookByIsbn(request.isbn())).willReturn(newBook);
+      given(readBookRepository.save(any(ReadBook.class))).willAnswer(
+          invocation -> invocation.getArgument(0));
+
+      // when
+      ReadBookResponse response = readBookService.addReadBook(request, memberId);
+
+      // then
+      assertNotNull(response);
+      verify(bookService).findOrCreateBookByIsbn(request.isbn());
+      verify(readBookRepository).save(any(ReadBook.class));
+    }
+
+    @DisplayName("도서가 DB에 이미 존재하는 경우, 읽은 책 등록에 성공한다")
+    @Test
+    void shouldSaveReadBook_whenBookExists() {
+      // given
+      Long memberId = 1L;
+      CreateReadBookRequest request = new CreateReadBookRequest(
+          "1234567890",    // isbn
+          "existingTitle",
+          "existingAuthor",
+          "existingPublisher",
+          "2022-12-31",
+          "http://existingcover.url",
+          LocalDate.now()
+      );
+
+      Member member = MemberTestHelper.createTestUser();
+      Book existingBook = BookTestHelper.createBook();  // 이미 DB에 있다고 가정
+
+      given(memberService.findMemberById(memberId)).willReturn(member);
+      given(bookService.findOrCreateBookByIsbn(request.isbn())).willReturn(existingBook);
+      given(readBookRepository.save(any(ReadBook.class))).willAnswer(
+          invocation -> invocation.getArgument(0));
+
+      // when
+      ReadBookResponse response = readBookService.addReadBook(request, memberId);
+
+      // then
+      assertNotNull(response);
+      verify(bookService).findOrCreateBookByIsbn(request.isbn());
+      verify(readBookRepository).save(any(ReadBook.class));
+    }
+  }
+}


### PR DESCRIPTION
# [#44] 읽은 도서 등록 기능 구현

---

## 📌 개요

사용자가 읽은 책을 등록하는 기능을 구현하였습니다.  
이번 작업에서는 도서 엔티티, DTO, 서비스 구현 및 서비스 단위 테스트 코드를 작성하였습니다.

---

## ✨ 주요 변경 사항

- `Book`, `ReadBook` 엔티티
- 읽은 책 등록을 위한 DTO (`CreateReadBookRequest`, `ReadBookResponse`) 추가  
- `ReadBookService`에 읽은 책 등록 기능 구현 (`addReadBook`)
- `ReadBookServiceTest` 단위 테스트 작성

---

## ✅ 테스트

- 단위 테스트: `ReadBookServiceTest`  
- 테스트 시나리오  
  - 도서가 DB에 없을 경우 새 도서 생성 후 읽은 책 등록  
  - 도서가 DB에 이미 존재할 경우 바로 읽은 책 등록  

---

## 🔖 참고

- `BookTestHelper`, `MemberTestHelper` 테스트 유틸 클래스 활용
---

## 🔗 관련 이슈

Related #44
