### PR TITLE
[FEATURE] 도서 검색 및 조회 기능 추가

### DIFF
--- a/src/main/java/com/clover/bookflow/domain/book/client/AladinApiClient.java
+++ b/src/main/java/com/clover/bookflow/domain/book/client/AladinApiClient.java
@@ -2,6 +2,7 @@ package com.clover.bookflow.domain.book.client;
 
 import com.clover.bookflow.domain.book.dto.AladinResponseDto;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
@@ -15,6 +16,24 @@ public class AladinApiClient { // 실제 API 호출
 
   public AladinApiClient(RestClient restClient) {
     this.restClient = restClient;
+  }
+
+  public AladinResponseDto searchBooks(String keyword, Pageable pageable) {
+    return restClient.get()
+        .uri(uriBuilder -> uriBuilder
+            .path("/ItemSearch.aspx")
+            .queryParam("ttbkey", ttbKey)
+            .queryParam("Query", keyword)
+            .queryParam("QueryType", "Keyword")
+            .queryParam("MaxResults", pageable.getPageSize())
+            .queryParam("start", pageable.getPageNumber() * pageable.getPageSize() + 1)
+            .queryParam("SearchTarget", "Book")
+            .queryParam("output", "js")  // json으로 받으려면 js
+            .queryParam("Version", "20131101")
+            .build())
+        .retrieve()
+        .body(AladinResponseDto.class);
+
   }
 
   public AladinResponseDto fetchBestSellers() {

--- a/src/main/java/com/clover/bookflow/domain/book/client/AladinApiClient.java
+++ b/src/main/java/com/clover/bookflow/domain/book/client/AladinApiClient.java
@@ -36,6 +36,21 @@ public class AladinApiClient { // 실제 API 호출
 
   }
 
+  public AladinResponseDto fetchBookByIsbn(String isbn13) {
+
+    return restClient.get()
+        .uri(uriBuilder -> uriBuilder
+            .path("/ItemLookUp.aspx")
+            .queryParam("ttbkey", ttbKey)
+            .queryParam("ItemId", isbn13)
+            .queryParam("Cover", "Mid") // 생략 가능 (기본값)
+            .queryParam("Output", "JS") // JSON 응답
+            .queryParam("Version", "20131101")
+            .build())
+        .retrieve()
+        .body(AladinResponseDto.class);
+  }
+
   public AladinResponseDto fetchBestSellers() {
     return restClient.get()
         .uri(uriBuilder -> uriBuilder

--- a/src/main/java/com/clover/bookflow/domain/book/controller/BookController.java
+++ b/src/main/java/com/clover/bookflow/domain/book/controller/BookController.java
@@ -1,0 +1,36 @@
+package com.clover.bookflow.domain.book.controller;
+
+import com.clover.bookflow.domain.book.dto.BookSearchResponse;
+import com.clover.bookflow.domain.book.service.BookService;
+import com.clover.bookflow.global.response.ApiResponse;
+import com.clover.bookflow.global.response.PageResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/book")
+@RequiredArgsConstructor
+public class BookController {
+
+  private final BookService bookService;
+
+  @GetMapping("/search")
+  public ResponseEntity<ApiResponse<PageResponse<BookSearchResponse>>> searchBook(
+      @RequestParam String keyword,
+      @PageableDefault(size = 10) Pageable pageable
+  ) {
+    Page<BookSearchResponse> page = bookService.searchBooks(keyword, pageable);
+    PageResponse<BookSearchResponse> pageResponse = PageResponse.from(page);
+
+    return ResponseEntity.ok(ApiResponse.success(pageResponse));
+
+  }
+
+}

--- a/src/main/java/com/clover/bookflow/domain/book/dto/BookSearchResponse.java
+++ b/src/main/java/com/clover/bookflow/domain/book/dto/BookSearchResponse.java
@@ -1,0 +1,15 @@
+package com.clover.bookflow.domain.book.dto;
+
+import java.time.LocalDate;
+
+public record BookSearchResponse(
+    String isbn,
+    String title,
+    String author,
+    String publisher,
+    String coverImgUrl,
+    LocalDate publishedDate,
+    String category
+) {
+
+}

--- a/src/main/java/com/clover/bookflow/domain/book/entity/Book.java
+++ b/src/main/java/com/clover/bookflow/domain/book/entity/Book.java
@@ -2,6 +2,7 @@ package com.clover.bookflow.domain.book.entity;
 
 import com.clover.bookflow.global.common.BaseTimeEntity;
 import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -25,6 +26,7 @@ public class Book extends BaseTimeEntity {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
+  @Column(unique = true)
   private String isbn;
 
   private String title;

--- a/src/main/java/com/clover/bookflow/domain/book/service/AladinApiService.java
+++ b/src/main/java/com/clover/bookflow/domain/book/service/AladinApiService.java
@@ -2,6 +2,7 @@ package com.clover.bookflow.domain.book.service;
 
 import com.clover.bookflow.domain.book.client.AladinApiClient;
 import com.clover.bookflow.domain.book.dto.AladinResponseDto;
+import com.clover.bookflow.domain.book.dto.AladinResponseDto.Item;
 import com.clover.bookflow.domain.book.dto.BookSaveRequestDto;
 import com.clover.bookflow.domain.book.dto.BookSearchResponse;
 import java.util.List;
@@ -24,6 +25,10 @@ public class AladinApiService { //  클라이언트 호출 + 로직 + 예외 처
   public Page<BookSearchResponse> searchBooks(String keyword, Pageable pageable) {
     AladinResponseDto response = aladinApiClient.searchBooks(keyword, pageable);
 
+    if (response == null || response.items() == null || response.items().isEmpty()) {
+      throw new RuntimeException("알라딘 응답이 비어있습니다.");
+    }
+
     List<BookSearchResponse> result = response.items().stream()
         .map(item -> new BookSearchResponse(
             item.isbn13(),
@@ -37,6 +42,30 @@ public class AladinApiService { //  클라이언트 호출 + 로직 + 예외 처
         .toList();
 
     return new PageImpl<>(result, pageable, response.totalResults());
+  }
+
+  // 선택한 도서 찾기
+  public BookSaveRequestDto fetchBookByIsbn(String isbn) {
+    AladinResponseDto response = aladinApiClient.fetchBookByIsbn(isbn);
+
+    if (response == null || response.items() == null || response.items().isEmpty()) {
+      throw new RuntimeException("알라딘 응답이 비어있습니다.");
+    }
+
+    Item item = response.items().get(0); // 단건 추출
+
+    return new BookSaveRequestDto(
+        item.isbn13(),
+        item.title(),
+        item.author(),
+        item.publisher(),
+        item.cover(),
+        item.pubDate(),
+        item.description(),
+        item.categoryName()
+    );
+
+
   }
 
   // 베스트셀러 리스트

--- a/src/main/java/com/clover/bookflow/domain/book/service/AladinApiService.java
+++ b/src/main/java/com/clover/bookflow/domain/book/service/AladinApiService.java
@@ -3,9 +3,13 @@ package com.clover.bookflow.domain.book.service;
 import com.clover.bookflow.domain.book.client.AladinApiClient;
 import com.clover.bookflow.domain.book.dto.AladinResponseDto;
 import com.clover.bookflow.domain.book.dto.BookSaveRequestDto;
+import com.clover.bookflow.domain.book.dto.BookSearchResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -17,7 +21,23 @@ public class AladinApiService { //  클라이언트 호출 + 로직 + 예외 처
   private final AladinApiClient aladinApiClient;
 
   // Todo: 검색 (모든 도서 db 사전 저장은 한계 있다. db 에 없는 도서 검색 api 호출 후 개별 도서 저장 로직 구현)
+  public Page<BookSearchResponse> searchBooks(String keyword, Pageable pageable) {
+    AladinResponseDto response = aladinApiClient.searchBooks(keyword, pageable);
 
+    List<BookSearchResponse> result = response.items().stream()
+        .map(item -> new BookSearchResponse(
+            item.isbn13(),
+            item.title(),
+            item.author(),
+            item.publisher(),
+            item.cover(),
+            item.pubDate(),
+            item.categoryName()
+        ))
+        .toList();
+
+    return new PageImpl<>(result, pageable, response.totalResults());
+  }
 
   // 베스트셀러 리스트
   public List<BookSaveRequestDto> fetchBestSellers() {

--- a/src/main/java/com/clover/bookflow/domain/book/service/BookService.java
+++ b/src/main/java/com/clover/bookflow/domain/book/service/BookService.java
@@ -107,10 +107,17 @@ public class BookService {
     return bookRepository.findExistingIsbns(isbns);
   }
 
-
+  // 도서 검색
+  // 해당 도서 추가
+  // 선택한 도서가 있는지 확인 및 없으면 저장
+  @Transactional
   public Book findOrCreateBookByIsbn(String isbn) {
-    return null;
-    //Todo: Book, BookDetail 구조 리팩토링 진행 및 전체 패키지 구조 리팩토링 진행
+    return bookRepository.findByIsbn(isbn)
+        .orElseGet(() -> {
+          BookSaveRequestDto dto = aladinApiService.fetchBookByIsbn(isbn);
+          Book book = dto.toEntity();
+          return bookRepository.save(book);
+        });
   }
 
   // 도서 검색

--- a/src/main/java/com/clover/bookflow/domain/book/service/BookService.java
+++ b/src/main/java/com/clover/bookflow/domain/book/service/BookService.java
@@ -3,6 +3,7 @@ package com.clover.bookflow.domain.book.service;
 import com.clover.bookflow.domain.book.dto.BookAllSaveRequestDto;
 import com.clover.bookflow.domain.book.dto.BookDetailSaveRequestDto;
 import com.clover.bookflow.domain.book.dto.BookSaveRequestDto;
+import com.clover.bookflow.domain.book.dto.BookSearchResponse;
 import com.clover.bookflow.domain.book.entity.Book;
 import com.clover.bookflow.domain.book.entity.BookDetail;
 import com.clover.bookflow.domain.book.repository.BookDetailRepository;
@@ -14,6 +15,8 @@ import java.util.Optional;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,6 +24,8 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class BookService {
+
+  private final AladinApiService aladinApiService;
 
   private final BookRepository bookRepository;
 
@@ -108,5 +113,9 @@ public class BookService {
     //Todo: Book, BookDetail 구조 리팩토링 진행 및 전체 패키지 구조 리팩토링 진행
   }
 
-  // 도서 조회
+  // 도서 검색
+  // 읽은 도서 목록에 도서 추가 시 사용
+  public Page<BookSearchResponse> searchBooks(String keyword, Pageable pageable) {
+    return aladinApiService.searchBooks(keyword, pageable);
+  }
 }

--- a/src/main/java/com/clover/bookflow/domain/readbook/dto/request/CreateReadBookRequest.java
+++ b/src/main/java/com/clover/bookflow/domain/readbook/dto/request/CreateReadBookRequest.java
@@ -4,11 +4,6 @@ import java.time.LocalDate;
 
 public record CreateReadBookRequest(
     String isbn,
-    String title,
-    String author,
-    String publisher,
-    String publishedDate,
-    String coverUrl,
     LocalDate readDate
 ) {
 

--- a/src/test/java/com/clover/bookflow/domain/book/service/BookServiceTest.java
+++ b/src/test/java/com/clover/bookflow/domain/book/service/BookServiceTest.java
@@ -1,0 +1,208 @@
+package com.clover.bookflow.domain.book.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyList;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.clover.bookflow.domain.book.dto.BookAllSaveRequestDto;
+import com.clover.bookflow.domain.book.dto.BookDetailSaveRequestDto;
+import com.clover.bookflow.domain.book.dto.BookSaveRequestDto;
+import com.clover.bookflow.domain.book.dto.BookSearchResponse;
+import com.clover.bookflow.domain.book.entity.Book;
+import com.clover.bookflow.domain.book.entity.BookDetail;
+import com.clover.bookflow.domain.book.repository.BookDetailRepository;
+import com.clover.bookflow.domain.book.repository.BookRepository;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+@DisplayName("BookService 단위 테스트")
+@ExtendWith(MockitoExtension.class)
+class BookServiceTest {
+
+  @InjectMocks
+  private BookService bookService;
+
+  @Mock
+  private AladinApiService aladinApiService;
+
+  @Mock
+  private BookRepository bookRepository;
+
+  @Mock
+  private BookDetailRepository bookDetailRepository;
+
+  private Book book;
+  private BookDetail detail;
+
+  @BeforeEach
+  void setUp() {
+    book = new Book("isbn123", "title", "author", "publisher",
+        "cover", LocalDate.now(), "description", "category");
+    detail = new BookDetail(book);
+  }
+
+  @Nested
+  @DisplayName("saveBooksWithDetails()")
+  class SaveBooksWithDetailsTest {
+
+    @DisplayName("도서 리스트를 저장한다")
+    @Test
+    void saveBooksWithDetails_shouldSaveAllBooks() {
+      BookAllSaveRequestDto dto = mock(BookAllSaveRequestDto.class);
+      given(dto.toEntity()).willReturn(book);
+
+      bookService.saveBooksWithDetails(List.of(dto));
+
+      verify(bookRepository).saveAll(anyList());
+    }
+  }
+
+  @Nested
+  @DisplayName("saveBasicBooks()")
+  class SaveBasicBooksTest {
+
+    @DisplayName("Book과 BookDetail을 함께 저장한다")
+    @Test
+    void saveBasicBooks_shouldSaveBooksAndDetails() {
+      BookSaveRequestDto dto = mock(BookSaveRequestDto.class);
+      given(dto.toEntity()).willReturn(book);
+
+      bookService.saveBasicBooks(Set.of(dto));
+
+      verify(bookRepository).saveAll(anyList());
+      verify(bookDetailRepository).saveAll(anyList());
+    }
+  }
+
+  @Nested
+  @DisplayName("saveBookDetails()")
+  class SaveBookDetailsTest {
+
+    @DisplayName("BookDetail이 없을 경우 새로 저장한다")
+    @Test
+    void saveBookDetails_shouldSaveNewBookDetails() {
+      BookDetailSaveRequestDto dto = mock(BookDetailSaveRequestDto.class);
+      given(dto.eaIsbn()).willReturn("isbn123");
+      given(bookRepository.findByIsbn("isbn123")).willReturn(Optional.of(book));
+      given(bookDetailRepository.findById(any())).willReturn(Optional.empty());
+      given(dto.toEntity(book)).willReturn(detail);
+
+      bookService.saveBookDetails(List.of(dto));
+
+      verify(bookDetailRepository).saveAll(anyList());
+    }
+
+    @DisplayName("기존 BookDetail이 있으면 업데이트한다")
+    @Test
+    void saveBookDetails_shouldUpdateExistingBookDetails() {
+      BookDetailSaveRequestDto dto = mock(BookDetailSaveRequestDto.class);
+      given(dto.eaIsbn()).willReturn("isbn123");
+      given(bookRepository.findByIsbn("isbn123")).willReturn(Optional.of(book));
+      given(bookDetailRepository.findById(any())).willReturn(Optional.of(detail));
+
+      bookService.saveBookDetails(List.of(dto));
+
+      verify(bookDetailRepository).saveAll(anyList());
+    }
+  }
+
+  @Nested
+  @DisplayName("findExistingIsbns()")
+  class FindExistingIsbnsTest {
+
+    @DisplayName("입력값이 null이면 빈 Set을 반환한다")
+    @Test
+    void returnEmptySetIfNull() {
+      Set<String> result = bookService.findExistingIsbns(null);
+      assertThat(result).isEmpty();
+    }
+
+    @DisplayName("입력값이 빈 Set이면 빈 Set을 반환한다")
+    @Test
+    void returnEmptySetIfEmpty() {
+      Set<String> result = bookService.findExistingIsbns(Set.of());
+      assertThat(result).isEmpty();
+    }
+
+    @DisplayName("DB에 존재하는 ISBN만 반환한다")
+    @Test
+    void returnMatchingIsbns() {
+      Set<String> input = Set.of("isbn1", "isbn2");
+      Set<String> output = Set.of("isbn2");
+
+      given(bookRepository.findExistingIsbns(input)).willReturn(output);
+
+      Set<String> result = bookService.findExistingIsbns(input);
+
+      assertThat(result).isEqualTo(output);
+    }
+  }
+
+  @Nested
+  @DisplayName("findOrCreateBookByIsbn()")
+  class FindOrCreateBookByIsbnTest {
+
+    @DisplayName("이미 존재하는 도서는 그대로 반환한다")
+    @Test
+    void returnExistingBook() {
+      given(bookRepository.findByIsbn("isbn123")).willReturn(Optional.of(book));
+
+      Book result = bookService.findOrCreateBookByIsbn("isbn123");
+
+      assertThat(result).isEqualTo(book);
+      verify(aladinApiService, never()).fetchBookByIsbn(any());
+    }
+
+    @DisplayName("존재하지 않으면 API로 가져와 저장 후 반환한다")
+    @Test
+    void fetchAndSaveIfNotExists() {
+      given(bookRepository.findByIsbn("isbn123")).willReturn(Optional.empty());
+
+      BookSaveRequestDto dto = mock(BookSaveRequestDto.class);
+      given(aladinApiService.fetchBookByIsbn("isbn123")).willReturn(dto);
+      given(dto.toEntity()).willReturn(book);
+      given(bookRepository.save(book)).willReturn(book);
+
+      Book result = bookService.findOrCreateBookByIsbn("isbn123");
+
+      assertThat(result).isEqualTo(book);
+      verify(bookRepository).save(book);
+    }
+  }
+
+  @Nested
+  @DisplayName("searchBooks()")
+  class SearchBooksTest {
+
+    @DisplayName("알라딘 API에 위임하여 도서를 검색한다")
+    @Test
+    void delegateSearchToApi() {
+      Pageable pageable = PageRequest.of(0, 10);
+      Page<BookSearchResponse> mockPage = new PageImpl<>(List.of());
+
+      given(aladinApiService.searchBooks("test", pageable)).willReturn(mockPage);
+
+      Page<BookSearchResponse> result = bookService.searchBooks("test", pageable);
+
+      assertThat(result).isEqualTo(mockPage);
+    }
+  }
+}

--- a/src/test/java/com/clover/bookflow/domain/readbook/service/ReadBookServiceTest.java
+++ b/src/test/java/com/clover/bookflow/domain/readbook/service/ReadBookServiceTest.java
@@ -50,11 +50,6 @@ class ReadBookServiceTest {
       Long memberId = 1L;
       CreateReadBookRequest request = new CreateReadBookRequest(
           "1234567890",    // isbn
-          "testtitle",     // title
-          "testauthor",
-          "testpublisher",
-          "2023-01-01",
-          "http://testcover.url",
           LocalDate.now()
       );
 
@@ -82,11 +77,6 @@ class ReadBookServiceTest {
       Long memberId = 1L;
       CreateReadBookRequest request = new CreateReadBookRequest(
           "1234567890",    // isbn
-          "existingTitle",
-          "existingAuthor",
-          "existingPublisher",
-          "2022-12-31",
-          "http://existingcover.url",
           LocalDate.now()
       );
 


### PR DESCRIPTION
# [#52] 도서 검색 및 조회 기능 추가

---

## 📌 개요

사용자가 읽은 책을 등록할 수 있도록,  
외부 API를 활용한 **도서 검색 및 조회 기능**을 추가했습니다.

또한 기존의 읽은 도서 등록 요청(`CreateReadBookRequest`) 필드를 개선하여,  
사용자가 검색 후 받은 **ISBN 값을 기반으로 외부 API에서 다시 도서 정보를 조회**하도록 변경했습니다.  
이를 통해 잘못된 입력으로 인한 **데이터 오염을 방지**할 수 있습니다.

---

## ✨ 주요 변경 사항

- `Book` 엔티티에 `isbn` 필드 **유니크 제약 조건 추가**
- `CreateReadBookRequest` DTO 필드 수정 및 관련 테스트 업데이트
- `BookService` 기능 추가:
  - 외부 API를 통한 **도서 검색**
  - ISBN 기반 외부 API **도서 상세 조회 및 저장**
- `BookServiceTest` 단위 테스트 작성

---

## ✅ 테스트

- 단위 테스트: `BookServiceTest` 통과

---

## 🔖 참고 사항

- 사용 외부 API: **알라딘 Open API**
- ISBN을 통해 정확한 도서 데이터를 확보하여 사용자 입력 오류 최소화

---

## 🔗 관련 이슈

- Related: #52  
- Related: #51  
- Related: #44  
