### PR TITLE
[Feature] 사용자 읽은 도서 목록 수정, 삭제, 조회 기능 추가

### DIFF
--- a/src/main/java/com/clover/bookflow/domain/auth/security/permission/ReadBookPermissionEvaluator.java
+++ b/src/main/java/com/clover/bookflow/domain/auth/security/permission/ReadBookPermissionEvaluator.java
@@ -1,0 +1,46 @@
+package com.clover.bookflow.domain.auth.security.permission;
+
+import com.clover.bookflow.domain.member.entity.Member;
+import com.clover.bookflow.domain.readbook.entity.ReadBook;
+import com.clover.bookflow.domain.readbook.repository.ReadBookRepository;
+import java.io.Serializable;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+
+@Component
+@RequiredArgsConstructor
+public class ReadBookPermissionEvaluator implements DomainPermissionEvaluator {
+
+    private final ReadBookRepository readBookRepository;
+
+    @Override
+    public boolean supports(String targetType) {
+        return "READ_BOOK".equalsIgnoreCase(targetType);
+    }
+
+    @Override
+    public boolean hasPermission(Authentication authentication, Serializable targetId, String permission) {
+        if (authentication == null || targetId == null || permission == null) {
+            return false;
+        }
+
+        Member currentUser = (Member) authentication.getPrincipal();
+
+        Optional<ReadBook> readBookOpt = readBookRepository.findById((Long) targetId);
+        if (readBookOpt.isEmpty()) {
+            return false;
+        }
+
+        ReadBook readBook = readBookOpt.get();
+
+        return switch (permission.toUpperCase()) {
+            case "READ" -> true; // 모든 사용자 조회 가능 (필요 시 제한)
+            case "WRITE" -> readBook.getMember().equals(currentUser); // 본인만 수정 가능
+            case "DELETE" -> readBook.getMember().equals(currentUser); // 본인만 삭제 가능
+            default -> false;
+        };
+    }
+}

--- a/src/main/java/com/clover/bookflow/domain/readbook/controller/ReadBookController.java
+++ b/src/main/java/com/clover/bookflow/domain/readbook/controller/ReadBookController.java
@@ -1,0 +1,78 @@
+package com.clover.bookflow.domain.readbook.controller;
+
+import com.clover.bookflow.domain.auth.security.CustomMemberDetails;
+import com.clover.bookflow.domain.readbook.dto.request.CreateReadBookRequest;
+import com.clover.bookflow.domain.readbook.dto.request.UpdateReadBookRequest;
+import com.clover.bookflow.domain.readbook.dto.response.ReadBookResponse;
+import com.clover.bookflow.domain.readbook.service.ReadBookService;
+import com.clover.bookflow.global.response.ApiResponse;
+import com.clover.bookflow.global.response.PageResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/read-books")
+@RequiredArgsConstructor
+public class ReadBookController {
+
+    private final ReadBookService readBookService;
+
+    @PreAuthorize("hasRole('USER')")
+    @PostMapping
+    public ResponseEntity<ApiResponse<ReadBookResponse>> addReadBook(
+            @RequestBody CreateReadBookRequest request,
+            @AuthenticationPrincipal CustomMemberDetails userDetails) {
+
+        ReadBookResponse readBookResponse = readBookService.addReadBook(request, userDetails.getId());
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(ApiResponse.success(readBookResponse));
+    }
+
+    @PreAuthorize("hasPermission(#readBookId,'Read_Book', 'WRITE')")
+    @PutMapping("/{readBookId}")
+    public ResponseEntity<ApiResponse<ReadBookResponse>> updateReadBook(
+            @PathVariable Long readBookId,
+            @RequestBody UpdateReadBookRequest request,
+            @AuthenticationPrincipal CustomMemberDetails userDetails) {
+
+        ReadBookResponse readBookResponse = readBookService.updateReadBook(readBookId, request, userDetails.getId());
+        return ResponseEntity.ok(ApiResponse.success(readBookResponse));
+    }
+
+    @PreAuthorize("hasPermission(#readBookId, 'Read_Book', 'DELETE')")
+    @DeleteMapping("/{readBookId}")
+    public ResponseEntity<ApiResponse<Void>> deleteReadBook(
+            @PathVariable Long readBookId,
+            @AuthenticationPrincipal CustomMemberDetails userDetails) {
+
+        readBookService.deleteReadBook(readBookId, userDetails.getId());
+        return ResponseEntity.noContent().build();
+    }
+
+    @PreAuthorize("hasRole('USER')")
+    @GetMapping
+    public ResponseEntity<ApiResponse<PageResponse<ReadBookResponse>>> getMyReadBooks(
+            @AuthenticationPrincipal CustomMemberDetails userDetails,
+            @PageableDefault(size = 10, sort = "createdDate", direction = Sort.Direction.DESC) Pageable pageable) {
+
+        Page<ReadBookResponse> page = readBookService.getReadBooksByMember(userDetails.getId(), pageable);
+        PageResponse<ReadBookResponse> pageResponse = PageResponse.from(page);
+        return ResponseEntity.ok(ApiResponse.success(pageResponse));
+    }
+}

--- a/src/main/java/com/clover/bookflow/domain/readbook/dto/request/UpdateReadBookRequest.java
+++ b/src/main/java/com/clover/bookflow/domain/readbook/dto/request/UpdateReadBookRequest.java
@@ -1,0 +1,10 @@
+package com.clover.bookflow.domain.readbook.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+
+public record UpdateReadBookRequest(
+
+        @NotNull LocalDate readDate
+) {
+}

--- a/src/main/java/com/clover/bookflow/domain/readbook/entity/ReadBook.java
+++ b/src/main/java/com/clover/bookflow/domain/readbook/entity/ReadBook.java
@@ -22,28 +22,32 @@ import lombok.NoArgsConstructor;
 @Table(name = "read_books")
 public class ReadBook extends BaseTimeEntity { // 사용자가 읽은 도서 목록 관리, 중간 엔티티
 
-  @Id
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
-  private Long id;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
-  @ManyToOne(fetch = FetchType.LAZY, optional = false)
-  @JoinColumn(name = "member_id")
-  private Member member;
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "member_id")
+    private Member member;
 
-  @ManyToOne(fetch = FetchType.LAZY, optional = false)
-  @JoinColumn(name = "book_id")
-  private Book book;
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "book_id")
+    private Book book;
 
-  private LocalDate readDate;
+    private LocalDate readDate;
 
-  private ReadBook(Member member, Book book, LocalDate readDate) {
-    this.member = member;
-    this.book = book;
-    this.readDate = readDate;
-  }
+    private ReadBook(Member member, Book book, LocalDate readDate) {
+        this.member = member;
+        this.book = book;
+        this.readDate = readDate;
+    }
 
-  public static ReadBook create(Member member, Book book, LocalDate readDate) {
-    return new ReadBook(member, book, readDate);
-  }
+    public static ReadBook create(Member member, Book book, LocalDate readDate) {
+        return new ReadBook(member, book, readDate);
+    }
+
+    public void updateReadDate(LocalDate newReadDate) {
+        this.readDate = newReadDate;
+    }
 
 }

--- a/src/main/java/com/clover/bookflow/domain/readbook/repository/ReadBookRepository.java
+++ b/src/main/java/com/clover/bookflow/domain/readbook/repository/ReadBookRepository.java
@@ -1,8 +1,11 @@
 package com.clover.bookflow.domain.readbook.repository;
 
 import com.clover.bookflow.domain.readbook.entity.ReadBook;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReadBookRepository extends JpaRepository<ReadBook, Long> {
 
+    Page<ReadBook> findAllByMemberId(Long memberId, Pageable pageable);
 }

--- a/src/main/java/com/clover/bookflow/domain/readbook/service/ReadBookService.java
+++ b/src/main/java/com/clover/bookflow/domain/readbook/service/ReadBookService.java
@@ -1,15 +1,23 @@
 package com.clover.bookflow.domain.readbook.service;
 
+import com.clover.bookflow.domain.auth.security.CustomMemberDetails;
 import com.clover.bookflow.domain.book.entity.Book;
 import com.clover.bookflow.domain.book.service.BookService;
 import com.clover.bookflow.domain.member.entity.Member;
 import com.clover.bookflow.domain.member.service.MemberService;
 import com.clover.bookflow.domain.readbook.dto.request.CreateReadBookRequest;
+import com.clover.bookflow.domain.readbook.dto.request.UpdateReadBookRequest;
 import com.clover.bookflow.domain.readbook.dto.response.ReadBookResponse;
 import com.clover.bookflow.domain.readbook.entity.ReadBook;
 import com.clover.bookflow.domain.readbook.repository.ReadBookRepository;
+import com.clover.bookflow.global.errorcode.ReadBookErrorCode;
+import com.clover.bookflow.global.exception.BusinessException;
+import com.clover.bookflow.global.exception.ForbiddenException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,26 +26,69 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class ReadBookService {
 
-  private final ReadBookRepository readBookRepository;
-  private final MemberService memberService;
-  private final BookService bookService;
+    private final ReadBookRepository readBookRepository;
+    private final MemberService memberService;
+    private final BookService bookService;
 
-  @Transactional
-  public ReadBookResponse addReadBook(CreateReadBookRequest request, Long memberId) {
-    // 1. 회원 조회
-    Member member = memberService.findMemberById(memberId);
+    @Transactional
+    public ReadBookResponse addReadBook(CreateReadBookRequest request, Long memberId) {
+        // 1. 회원 조회
+        Member member = memberService.findMemberById(memberId);
 
-    // 2. 책 조회 (DB에 없으면 API 호출 후 저장)
-    Book book = bookService.findOrCreateBookByIsbn(request.isbn());
+        // 2. 책 조회 (DB에 없으면 API 호출 후 저장)
+        Book book = bookService.findOrCreateBookByIsbn(request.isbn());
 
-    // 3. 읽은 책 엔티티 생성 (중복 체크는 ReadBookRepository에서 별도 처리하거나 unique 제약조건 활용)
-    ReadBook readBook = ReadBook.create(member, book, request.readDate());
+        // 3. 읽은 책 엔티티 생성 (중복 체크는 ReadBookRepository에서 별도 처리하거나 unique 제약조건 활용)
+        ReadBook readBook = ReadBook.create(member, book, request.readDate());
+        // 등록일로 처리
+        // 지금 이건 단순한 읽은 읽고있는~ 읽었던 포함하는 도서 목록
 
-    // 4. 저장
-    readBookRepository.save(readBook);
+        // 4. 저장
+        readBookRepository.save(readBook);
 
-    // 5. DTO 변환 후 반환
-    return ReadBookResponse.from(readBook);
-  }
+        // 5. DTO 변환 후 반환
+        return ReadBookResponse.from(readBook);
+    }
+
+    @Transactional
+    public ReadBookResponse updateReadBook(Long readBookId, UpdateReadBookRequest request, Long memberId) {
+        ReadBook readBook = readBookRepository.findById(readBookId)
+                .orElseThrow(() -> new BusinessException(ReadBookErrorCode.READ_BOOK_NOT_FOUND));
+
+        if (!readBook.getMember().getId().equals(memberId)) {
+            throw new ForbiddenException(ReadBookErrorCode.ACCESS_DENIED);
+        }
+
+        readBook.updateReadDate(request.readDate());
+        return ReadBookResponse.from(readBook);
+    }
+
+    @Transactional
+    public void deleteReadBook(Long readBookId, Long memberId) {
+        ReadBook readBook = readBookRepository.findById(readBookId)
+                .orElseThrow(() -> new BusinessException(ReadBookErrorCode.READ_BOOK_NOT_FOUND));
+
+        if (!readBook.getMember().getId().equals(memberId)) {
+            throw new ForbiddenException(ReadBookErrorCode.ACCESS_DENIED);
+        }
+
+        readBookRepository.delete(readBook);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<ReadBookResponse> getReadBooksByMember(Long memberId, Pageable pageable) {
+        Page<ReadBook> readBooks = readBookRepository.findAllByMemberId(memberId, pageable);
+
+        return readBooks.map(ReadBookResponse::from);
+    }
+
+    /**
+     * SecurityContext에서 Member ID 가져온 후 DB에서 실제 Member 확인
+     */
+    private Member getCurrentMemberFromDb() {
+        var auth = SecurityContextHolder.getContext().getAuthentication();
+        Long memberId = ((CustomMemberDetails) auth.getPrincipal()).getId();
+        return memberService.findMemberById(memberId); // DB 조회 후 없으면 예외 발생
+    }
 
 }

--- a/src/main/java/com/clover/bookflow/global/errorcode/ReadBookErrorCode.java
+++ b/src/main/java/com/clover/bookflow/global/errorcode/ReadBookErrorCode.java
@@ -6,19 +6,20 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum ReadBookErrorCode implements ErrorCode {
 
-  READ_BOOK_NOT_FOUND("READ_BOOK_001", "읽은 책을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
-  INVALID_ISBN("READ_BOOK_002", "유효하지 않은 ISBN입니다.", HttpStatus.BAD_REQUEST),
-  DUPLICATE_READ_BOOK("READ_BOOK_003", "이미 등록된 읽은 책입니다.", HttpStatus.CONFLICT);
+    READ_BOOK_NOT_FOUND("READ_BOOK_001", "읽은 책을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    INVALID_ISBN("READ_BOOK_002", "유효하지 않은 ISBN입니다.", HttpStatus.BAD_REQUEST),
+    DUPLICATE_READ_BOOK("READ_BOOK_003", "이미 등록된 읽은 책입니다.", HttpStatus.CONFLICT),
+    ACCESS_DENIED("READ_BOOK_004", "본인의 읽은 도서만 수정/삭제할 수 있습니다.", HttpStatus.FORBIDDEN);
 
-  private final String code;
-  private final String message;
-  private final HttpStatus status;
+    private final String code;
+    private final String message;
+    private final HttpStatus status;
 
-  // enum은 특별한 클래스라서, 생성자를 명시적으로 작성하는 게 가독성에 좋고, Lombok 어노테이션과 충돌 가능성도 줄어듦
-  ReadBookErrorCode(String code, String message, HttpStatus status) {
-    this.code = code;
-    this.message = message;
-    this.status = status;
-  }
+    // enum은 특별한 클래스라서, 생성자를 명시적으로 작성하는 게 가독성에 좋고, Lombok 어노테이션과 충돌 가능성도 줄어듦
+    ReadBookErrorCode(String code, String message, HttpStatus status) {
+        this.code = code;
+        this.message = message;
+        this.status = status;
+    }
 
 }

--- a/src/main/java/com/clover/bookflow/global/errorcode/ReadBookErrorCode.java
+++ b/src/main/java/com/clover/bookflow/global/errorcode/ReadBookErrorCode.java
@@ -1,0 +1,24 @@
+package com.clover.bookflow.global.errorcode;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ReadBookErrorCode implements ErrorCode {
+
+  READ_BOOK_NOT_FOUND("READ_BOOK_001", "읽은 책을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+  INVALID_ISBN("READ_BOOK_002", "유효하지 않은 ISBN입니다.", HttpStatus.BAD_REQUEST),
+  DUPLICATE_READ_BOOK("READ_BOOK_003", "이미 등록된 읽은 책입니다.", HttpStatus.CONFLICT);
+
+  private final String code;
+  private final String message;
+  private final HttpStatus status;
+
+  // enum은 특별한 클래스라서, 생성자를 명시적으로 작성하는 게 가독성에 좋고, Lombok 어노테이션과 충돌 가능성도 줄어듦
+  ReadBookErrorCode(String code, String message, HttpStatus status) {
+    this.code = code;
+    this.message = message;
+    this.status = status;
+  }
+
+}

--- a/src/main/java/com/clover/bookflow/global/exception/ForbiddenException.java
+++ b/src/main/java/com/clover/bookflow/global/exception/ForbiddenException.java
@@ -1,0 +1,12 @@
+package com.clover.bookflow.global.exception;
+
+import com.clover.bookflow.global.errorcode.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class ForbiddenException extends CustomException {
+
+    public ForbiddenException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/test/java/com/clover/bookflow/docs/RestDocsTestSupport.java
+++ b/src/test/java/com/clover/bookflow/docs/RestDocsTestSupport.java
@@ -1,0 +1,48 @@
+package com.clover.bookflow.docs;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+
+import com.clover.bookflow.config.SecurityConfig;
+import com.clover.bookflow.domain.auth.security.JwtAuthenticationFilter;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+@Import(SecurityConfig.class)
+@ExtendWith({RestDocumentationExtension.class, SpringExtension.class})
+@WebMvcTest
+public abstract class RestDocsTestSupport {
+
+    @Autowired
+    protected MockMvc mockMvc;
+
+    @Autowired
+    protected ObjectMapper objectMapper;
+
+    @Autowired
+    protected WebApplicationContext context;
+
+    @MockitoBean
+    protected JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @BeforeEach
+    void setUp(RestDocumentationContextProvider provider) {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
+                .apply(documentationConfiguration(provider)
+                        .operationPreprocessors()
+                        .withRequestDefaults(prettyPrint())
+                        .withResponseDefaults(prettyPrint()))
+                .build();
+    }
+}

--- a/src/test/java/com/clover/bookflow/domain/readbook/controller/ReadBookControllerTest.java
+++ b/src/test/java/com/clover/bookflow/domain/readbook/controller/ReadBookControllerTest.java
@@ -1,0 +1,229 @@
+package com.clover.bookflow.domain.readbook.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.clover.bookflow.common.TestHelper;
+import com.clover.bookflow.config.SecurityConfig;
+import com.clover.bookflow.domain.auth.security.JwtAuthenticationFilter;
+import com.clover.bookflow.domain.auth.security.annotation.WithMockCustomUser;
+import com.clover.bookflow.domain.readbook.dto.request.CreateReadBookRequest;
+import com.clover.bookflow.domain.readbook.dto.request.UpdateReadBookRequest;
+import com.clover.bookflow.domain.readbook.dto.response.ReadBookResponse;
+import com.clover.bookflow.domain.readbook.service.ReadBookService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+@WebMvcTest(ReadBookController.class)
+@Import(SecurityConfig.class)
+@ExtendWith({RestDocumentationExtension.class, SpringExtension.class})
+class ReadBookControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+    @MockitoBean
+    private ReadBookService readBookService;
+    @MockitoBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+    @Autowired
+    private WebApplicationContext context;
+
+    private static final String BASE_URL = "/api/v1/read-books";
+    private TestHelper testHelper;
+
+    @BeforeEach
+    void setUp(RestDocumentationContextProvider provider) {
+        this.mockMvc =
+                MockMvcBuilders.webAppContextSetup(context)
+                        .apply(documentationConfiguration(provider)
+                                .operationPreprocessors()
+                                .withRequestDefaults(prettyPrint())
+                                .withResponseDefaults(prettyPrint()))
+                        .build();
+
+        testHelper = new TestHelper(mockMvc, objectMapper);
+    }
+
+    @Test
+    @DisplayName("should_returnCreatedReadBook_when_addReadBookRequestIsValid")
+    @WithMockCustomUser
+    void should_returnCreatedReadBook_when_addReadBookRequestIsValid() throws Exception {
+        // given
+        CreateReadBookRequest request = new CreateReadBookRequest("isbnofthebook", LocalDate.of(2024, 10, 15));
+        ReadBookResponse response = new ReadBookResponse(
+                1L, 10L, 1L, "Effective Java", "Joshua Bloch",
+                "https://example.com/cover.jpg", LocalDate.of(2024, 10, 15));
+
+        given(readBookService.addReadBook(any(CreateReadBookRequest.class), any(Long.class)))
+                .willReturn(response);
+
+        // when & then
+        MvcResult result = mockMvc.perform(post(BASE_URL)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.success").value("true"))
+                .andExpect(jsonPath("$.data.title").value("Effective Java"))
+                .andDo(document(
+                        "read-book/create",
+                        requestFields(
+                                fieldWithPath("isbn").description("책 isbn"),
+                                fieldWithPath("readDate").description("책을 읽은 날짜")
+                        ),
+                        responseFields(
+                                fieldWithPath("success").description("요청 성공 여부"),
+                                fieldWithPath("code").description("응답 코드"),
+                                fieldWithPath("message").description("응답 메시지"),
+                                fieldWithPath("data.readBookId").description("읽은 책 ID"),
+                                fieldWithPath("data.memberId").description("회원 ID"),
+                                fieldWithPath("data.bookId").description("책 ID"),
+                                fieldWithPath("data.title").description("책 제목"),
+                                fieldWithPath("data.author").description("책 저자"),
+                                fieldWithPath("data.coverImgUrl").description("책 표지 이미지 URL"),
+                                fieldWithPath("data.readDate").description("읽은 날짜"),
+
+                                fieldWithPath("errors").description("에러 목록")
+                        )
+                ))
+                .andReturn();
+    }
+
+    @Test
+    @DisplayName("should_updateReadBook_when_validUpdateRequest")
+    @WithMockCustomUser
+    void should_updateReadBook_when_validUpdateRequest() throws Exception {
+        // given
+        Long readBookId = 1L;
+        UpdateReadBookRequest request = new UpdateReadBookRequest(LocalDate.of(2024, 11, 1));
+        ReadBookResponse response = new ReadBookResponse(
+                readBookId, 10L, 1L, "Effective Java", "Joshua Bloch",
+                "https://example.com/cover.jpg", LocalDate.of(2024, 11, 1));
+
+        given(readBookService.updateReadBook(eq(readBookId), any(UpdateReadBookRequest.class), any(Long.class)))
+                .willReturn(response);
+
+        // when & then
+        mockMvc.perform(put(BASE_URL + "/{readBookId}", readBookId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.readBookId").value(1L))
+                .andDo(document(
+                        "read-book/update",
+                        pathParameters(parameterWithName("readBookId").description("읽은 책 ID")),
+                        requestFields(
+                                fieldWithPath("readDate").description("수정된 읽은 날짜")
+                        ),
+                        responseFields(
+                                fieldWithPath("success").description("요청 성공 여부"),
+                                fieldWithPath("code").description("응답 코드"),
+                                fieldWithPath("message").description("응답 메시지"),
+                                fieldWithPath("data.readBookId").description("읽은 책 ID"),
+                                fieldWithPath("data.memberId").description("회원 ID"),
+                                fieldWithPath("data.bookId").description("책 ID"),
+                                fieldWithPath("data.title").description("책 제목"),
+                                fieldWithPath("data.author").description("책 저자"),
+                                fieldWithPath("data.coverImgUrl").description("책 표지 이미지 URL"),
+                                fieldWithPath("data.readDate").description("수정된 읽은 날짜"),
+                                fieldWithPath("errors").description("에러 목록")
+                        )
+                ))
+                .andReturn();
+    }
+
+    @Test
+    @DisplayName("should_deleteReadBook_when_validDeleteRequest")
+    @WithMockCustomUser
+    void should_deleteReadBook_when_validDeleteRequest() throws Exception {
+        // given
+        Long readBookId = 1L;
+
+        // when & then
+        mockMvc.perform(delete(BASE_URL + "/{readBookId}", readBookId))
+                .andExpect(status().isNoContent())
+                .andDo(document(
+                        "read-book/delete",
+                        pathParameters(parameterWithName("readBookId").description("삭제할 읽은 책 ID"))
+                ));
+    }
+
+    @Test
+    @DisplayName("should_returnPagedReadBooks_when_getMyReadBooks")
+    @WithMockCustomUser
+    void should_returnPagedReadBooks_when_getMyReadBooks() throws Exception {
+        // given
+        ReadBookResponse book1 = new ReadBookResponse(1L, 10L, 100L, "Book1", "Author1", "https://img1",
+                LocalDate.now());
+        ReadBookResponse book2 = new ReadBookResponse(2L, 10L, 101L, "Book2", "Author2", "https://img2",
+                LocalDate.now());
+        Page<ReadBookResponse> page = new PageImpl<>(List.of(book1, book2), PageRequest.of(0, 10), 2);
+
+        given(readBookService.getReadBooksByMember(any(Long.class), any(Pageable.class))).willReturn(page);
+
+        // when & then
+        mockMvc.perform(get(BASE_URL)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andDo(document(
+                        "read-book/get-my-read-books",
+                        responseFields(
+                                fieldWithPath("success").description("요청 성공 여부"),
+                                fieldWithPath("code").description("응답 코드"),
+                                fieldWithPath("message").description("응답 메시지"),
+                                fieldWithPath("data.content[].readBookId").description("읽은 책 ID"),
+                                fieldWithPath("data.content[].memberId").description("회원 ID"),
+                                fieldWithPath("data.content[].bookId").description("책 ID"),
+                                fieldWithPath("data.content[].title").description("책 제목"),
+                                fieldWithPath("data.content[].author").description("책 저자"),
+                                fieldWithPath("data.content[].coverImgUrl").description("책 표지 이미지 URL"),
+                                fieldWithPath("data.content[].readDate").description("읽은 날짜"),
+                                fieldWithPath("data.pagination.page").description("현재 페이지 번호"),
+                                fieldWithPath("data.pagination.size").description("페이지 크기"),
+                                fieldWithPath("data.pagination.totalPages").description("전체 페이지 수"),
+                                fieldWithPath("data.pagination.totalElements").description("전체 데이터 수"),
+                                fieldWithPath("data.pagination.first").description("첫 페이지 여부"),
+                                fieldWithPath("data.pagination.last").description("마지막 페이지 여부"),
+                                fieldWithPath("errors").description("에러 목록")
+                        )
+                ))
+                .andReturn();
+    }
+}

--- a/src/test/java/com/clover/bookflow/domain/readbook/service/ReadBookServiceTest.java
+++ b/src/test/java/com/clover/bookflow/domain/readbook/service/ReadBookServiceTest.java
@@ -1,6 +1,7 @@
 package com.clover.bookflow.domain.readbook.service;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
@@ -10,12 +11,22 @@ import com.clover.bookflow.domain.book.entity.BookTestHelper;
 import com.clover.bookflow.domain.book.service.BookService;
 import com.clover.bookflow.domain.member.entity.Member;
 import com.clover.bookflow.domain.member.entity.MemberTestHelper;
+import com.clover.bookflow.domain.member.enums.MemberStatus;
+import com.clover.bookflow.domain.member.enums.Role;
 import com.clover.bookflow.domain.member.service.MemberService;
 import com.clover.bookflow.domain.readbook.dto.request.CreateReadBookRequest;
+import com.clover.bookflow.domain.readbook.dto.request.UpdateReadBookRequest;
 import com.clover.bookflow.domain.readbook.dto.response.ReadBookResponse;
 import com.clover.bookflow.domain.readbook.entity.ReadBook;
 import com.clover.bookflow.domain.readbook.repository.ReadBookRepository;
+import com.clover.bookflow.global.errorcode.ReadBookErrorCode;
+import com.clover.bookflow.global.exception.BusinessException;
+import com.clover.bookflow.global.exception.ForbiddenException;
 import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -23,78 +34,209 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 
 @ExtendWith(MockitoExtension.class)
 class ReadBookServiceTest {
 
-  @Mock
-  private MemberService memberService;
+    @Mock
+    private MemberService memberService;
 
-  @Mock
-  private BookService bookService;
+    @Mock
+    private BookService bookService;
 
-  @Mock
-  private ReadBookRepository readBookRepository;
+    @Mock
+    private ReadBookRepository readBookRepository;
 
-  @InjectMocks
-  private ReadBookService readBookService;
+    @InjectMocks
+    private ReadBookService readBookService;
 
-  @Nested
-  @DisplayName("addReadBook 메서드 테스트")
-  class AddReadBookTests {
+    private Member member;
+    private Member otherMember;
+    private Book book;
 
-    @DisplayName("도서가 DB에 없는 경우, 도서를 생성하고 읽은 책 등록에 성공한다")
-    @Test
-    void shouldCreateBookAndSaveReadBook_whenBookNotExist() {
-      // given
-      Long memberId = 1L;
-      CreateReadBookRequest request = new CreateReadBookRequest(
-          "1234567890",    // isbn
-          LocalDate.now()
-      );
+    @BeforeEach
+    void setUp() {
+        // 공통 테스트용 Member, 다른 Member
+        member = MemberTestHelper.createTestMemberWithId(
+                1L, UUID.randomUUID(), "test@example.com", "password123",
+                "testNickname", Role.USER, MemberStatus.ACTIVE
+        );
 
-      Member member = MemberTestHelper.createTestUser();
-      Book newBook = BookTestHelper.createBook();
+        otherMember = MemberTestHelper.createTestMemberWithId(
+                2L, UUID.randomUUID(), "other@example.com", "password456",
+                "otherNickname", Role.USER, MemberStatus.ACTIVE
+        );
 
-      given(memberService.findMemberById(memberId)).willReturn(member);
-      given(bookService.findOrCreateBookByIsbn(request.isbn())).willReturn(newBook);
-      given(readBookRepository.save(any(ReadBook.class))).willAnswer(
-          invocation -> invocation.getArgument(0));
-
-      // when
-      ReadBookResponse response = readBookService.addReadBook(request, memberId);
-
-      // then
-      assertNotNull(response);
-      verify(bookService).findOrCreateBookByIsbn(request.isbn());
-      verify(readBookRepository).save(any(ReadBook.class));
+        // 공통 테스트용 Book
+        book = BookTestHelper.createBook();
     }
 
-    @DisplayName("도서가 DB에 이미 존재하는 경우, 읽은 책 등록에 성공한다")
-    @Test
-    void shouldSaveReadBook_whenBookExists() {
-      // given
-      Long memberId = 1L;
-      CreateReadBookRequest request = new CreateReadBookRequest(
-          "1234567890",    // isbn
-          LocalDate.now()
-      );
+    @Nested
+    @DisplayName("addReadBook 메서드 테스트")
+    class AddReadBookTests {
 
-      Member member = MemberTestHelper.createTestUser();
-      Book existingBook = BookTestHelper.createBook();  // 이미 DB에 있다고 가정
+        @Test
+        @DisplayName("도서가 DB에 없는 경우, 도서를 생성하고 읽은 책 등록에 성공한다")
+        void shouldCreateBookAndSaveReadBook_whenBookNotExist() {
+            Long memberId = member.getId();
+            CreateReadBookRequest request = new CreateReadBookRequest("1234567890", LocalDate.now());
 
-      given(memberService.findMemberById(memberId)).willReturn(member);
-      given(bookService.findOrCreateBookByIsbn(request.isbn())).willReturn(existingBook);
-      given(readBookRepository.save(any(ReadBook.class))).willAnswer(
-          invocation -> invocation.getArgument(0));
+            given(memberService.findMemberById(memberId)).willReturn(member);
+            given(bookService.findOrCreateBookByIsbn(request.isbn())).willReturn(book);
+            given(readBookRepository.save(any(ReadBook.class))).willAnswer(i -> i.getArgument(0));
 
-      // when
-      ReadBookResponse response = readBookService.addReadBook(request, memberId);
+            ReadBookResponse response = readBookService.addReadBook(request, memberId);
 
-      // then
-      assertNotNull(response);
-      verify(bookService).findOrCreateBookByIsbn(request.isbn());
-      verify(readBookRepository).save(any(ReadBook.class));
+            assertThat(response).isNotNull();
+            verify(bookService).findOrCreateBookByIsbn(request.isbn());
+            verify(readBookRepository).save(any(ReadBook.class));
+        }
+
+        @Test
+        @DisplayName("도서가 DB에 이미 존재하는 경우, 읽은 책 등록에 성공한다")
+        void shouldSaveReadBook_whenBookExists() {
+            Long memberId = member.getId();
+            CreateReadBookRequest request = new CreateReadBookRequest("1234567890", LocalDate.now());
+
+            given(memberService.findMemberById(memberId)).willReturn(member);
+            given(bookService.findOrCreateBookByIsbn(request.isbn())).willReturn(book);
+            given(readBookRepository.save(any(ReadBook.class))).willAnswer(i -> i.getArgument(0));
+
+            ReadBookResponse response = readBookService.addReadBook(request, memberId);
+
+            assertThat(response).isNotNull();
+            verify(bookService).findOrCreateBookByIsbn(request.isbn());
+            verify(readBookRepository).save(any(ReadBook.class));
+        }
     }
-  }
+
+    @Nested
+    @DisplayName("updateReadBook 메서드 테스트")
+    class UpdateReadBookTests {
+
+        @Test
+        @DisplayName("자신의 읽은 책이면 업데이트 성공")
+        void shouldUpdateReadBook_whenMemberIsOwner() {
+            Long readBookId = 100L;
+            LocalDate newDate = LocalDate.now();
+            UpdateReadBookRequest request = new UpdateReadBookRequest(newDate);
+
+            ReadBook readBook = ReadBook.create(member, book, LocalDate.now());
+            given(readBookRepository.findById(readBookId)).willReturn(Optional.of(readBook));
+
+            ReadBookResponse response = readBookService.updateReadBook(readBookId, request, member.getId());
+
+            assertThat(response).isNotNull();
+            assertThat(readBook.getReadDate()).isEqualTo(newDate);
+        }
+
+        @Test
+        @DisplayName("다른 사람 읽은 책이면 ForbiddenException 발생")
+        void shouldThrowForbiddenException_whenNotOwner() {
+            Long readBookId = 100L;
+            UpdateReadBookRequest request = new UpdateReadBookRequest(LocalDate.now());
+
+            ReadBook readBook = ReadBook.create(member, book, LocalDate.now());
+            given(readBookRepository.findById(readBookId)).willReturn(Optional.of(readBook));
+
+            assertThatThrownBy(() -> readBookService.updateReadBook(readBookId, request, otherMember.getId()))
+                    .isInstanceOf(ForbiddenException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ReadBookErrorCode.ACCESS_DENIED);
+        }
+
+        @Test
+        @DisplayName("읽은 책이 없으면 BusinessException 발생")
+        void shouldThrowBusinessException_whenReadBookNotFound() {
+            given(readBookRepository.findById(100L)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> readBookService.updateReadBook(
+                    100L, new UpdateReadBookRequest(LocalDate.now()), member.getId()))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ReadBookErrorCode.READ_BOOK_NOT_FOUND);
+        }
+    }
+
+    @Nested
+    @DisplayName("deleteReadBook 메서드 테스트")
+    class DeleteReadBookTests {
+
+        @Test
+        @DisplayName("자신의 읽은 책이면 삭제 성공")
+        void shouldDeleteReadBook_whenMemberIsOwner() {
+            Long readBookId = 100L;
+
+            ReadBook readBook = ReadBook.create(member, book, LocalDate.now());
+            given(readBookRepository.findById(readBookId)).willReturn(Optional.of(readBook));
+
+            readBookService.deleteReadBook(readBookId, member.getId());
+
+            verify(readBookRepository).delete(readBook);
+        }
+
+        @Test
+        @DisplayName("다른 사람 읽은 책이면 ForbiddenException 발생")
+        void shouldThrowForbiddenException_whenNotOwner() {
+            Long readBookId = 100L;
+
+            ReadBook readBook = ReadBook.create(member, book, LocalDate.now());
+            given(readBookRepository.findById(readBookId)).willReturn(Optional.of(readBook));
+
+            assertThatThrownBy(() -> readBookService.deleteReadBook(readBookId, otherMember.getId()))
+                    .isInstanceOf(ForbiddenException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ReadBookErrorCode.ACCESS_DENIED);
+        }
+
+        @Test
+        @DisplayName("읽은 책이 없으면 BusinessException 발생")
+        void shouldThrowBusinessException_whenReadBookNotFound() {
+            given(readBookRepository.findById(100L)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> readBookService.deleteReadBook(100L, member.getId()))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ReadBookErrorCode.READ_BOOK_NOT_FOUND);
+        }
+    }
+
+    @Nested
+    @DisplayName("getReadBooksByMember 메서드 테스트")
+    class GetReadBooksByMemberTests {
+
+        @Test
+        @DisplayName("회원의 읽은 책 목록 조회 성공")
+        void shouldReturnReadBooks_whenMemberHasReadBooks() {
+            ReadBook rb1 = ReadBook.create(member, book, LocalDate.now());
+            ReadBook rb2 = ReadBook.create(member, book, LocalDate.now().minusDays(1));
+
+            Pageable pageable = PageRequest.of(0, 10, Sort.by("createdDate").descending());
+            given(readBookRepository.findAllByMemberId(member.getId(), pageable))
+                    .willReturn(new PageImpl<>(List.of(rb1, rb2)));
+
+            Page<ReadBookResponse> responses = readBookService.getReadBooksByMember(member.getId(), pageable);
+
+            assertThat(responses.getContent()).hasSize(2);
+        }
+
+        @Test
+        @DisplayName("읽은 책이 없으면 빈 페이지 반환")
+        void shouldReturnEmptyList_whenNoReadBooks() {
+            Pageable pageable = PageRequest.of(0, 10, Sort.by("createdDate").descending());
+            given(readBookRepository.findAllByMemberId(member.getId(), pageable))
+                    .willReturn(Page.empty());
+
+            Page<ReadBookResponse> responses = readBookService.getReadBooksByMember(member.getId(), pageable);
+
+            assertThat(responses.getContent()).isEmpty();
+        }
+    }
+
 }
+


### PR DESCRIPTION
# [#44] 읽은 도서 목록 수정, 삭제, 조회 기능 추가

---

## 📌 개요
사용자의 **읽은 도서 목록 수정, 삭제, 조회 기능**을 추가했습니다.

---

## ✨ 주요 변경 사항
- `ReadBookService`, `ReadBookController` 구현
- 테스트 코드 추가
  - `ReadBookServiceTest`
  - `ReadBookControllerTest`
- RestDocs 공통 설정 클래스 추가

---

## ✅ 테스트
- [x] 단위 테스트 통과

---

## 🔖 참고
- 현재 `ControllerTest` 실행 후에 문서화가 업데이트되지 않는 이슈가 있습니다. (추후 수정 예정)

---

## 🔗 관련 이슈
- Closes: #44
